### PR TITLE
Add virus detection with bowtie2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -319,6 +319,10 @@ TARGETS += contest
 contest :
 	$(call RUN_MAKE,modules/contamination/contest.mk)
 
+TARGETS += virus_detection_bowtie2
+virus_detection_bowtie2 :
+	$(call RUN_MAKE,modules/virus/virus_detection_bowtie2.mk)
+
 
 .PHONY : $(TARGETS)
 

--- a/virus/virus_detection_bowtie2.mk
+++ b/virus/virus_detection_bowtie2.mk
@@ -1,0 +1,38 @@
+# This module gets the unmapped reads from the samples bam files and maps them
+# against a virus database. The coverage of the virus genomes is determined #
+# with BEDtools.
+# Author: inodb
+
+##### MAKE INCLUDES #####
+include modules/Makefile.inc
+
+LOGDIR = log/virus_detection_bowtie2.$(NOW)
+
+.SECONDARY:
+.DELETE_ON_ERROR:
+.PHONY: virus_detection_bowtie2
+
+VIRUS_DB ?= /ifs/e63data/reis-filho/reference/viral.1.1.genomic.renamed.fna
+VIRUS_DB_NAME ?= ncbi-viral
+
+virus_detection_bowtie2 : $(foreach sample,$(SAMPLES),virus/bowtie2/default/$(VIRUS_DB_NAME)/$(sample).bam.bedcov.summary.txt)
+
+VIRUS_MATE = <(grep '/$2$$' -A3 --no-group-separator $1)
+
+PYTHON_ENV ?= /ifs/e63data/reis-filho/usr/anaconda-envs/pyenv27-chasm
+
+virus/fastq/%.unmapped.il.fq virus/fastq/%.unmapped.single.fq: bam/%.bam
+	$(call LSCRIPT_MEM,2G,3G,"$(MKDIR) $(@D);  samtools view -uf 4 $< | samtools bam2fq - -s $(@D)/$*.unmapped.single.fq > $(@D)/$*.unmapped.il.fastq")
+
+virus/bowtie2/default/$(VIRUS_DB_NAME)/%.bam: virus/fastq/%.unmapped.il.fq virus/fastq/%.unmapped.single.fq
+	$(call LSCRIPT_MEM,2G,3G,"$(MKDIR) $(@D); bowtie2 -x $(VIRUS_DB) -U $(<<) -1 $(call VIRUS_MATE,$<,1) -2 $(call VIRUS_MATE,$<,2) | samtools view -bS - | samtools sort - -O bam -T `mktemp` > $@")
+
+virus/bowtie2/default/$(VIRUS_DB_NAME)/%.bam.bedcov.txt: virus/bowtie2/default/$(VIRUS_DB_NAME)/%.bam
+	$(call LSCRIPT_MEM,2G,3G,"genomeCoverageBed -ibam $< > $@")
+
+virus/bowtie2/default/$(VIRUS_DB_NAME)/%.bam.bedcov.summary.txt: virus/bowtie2/default/$(VIRUS_DB_NAME)/%.bam.bedcov.txt
+	$(INIT) source $(PYTHON_ENV)/bin/activate $(PYTHON_ENV) && \
+	echo -e '\
+import pandas as pd\n\
+cov = pd.read_csv("$<", sep="\t", names=["ref","cov","count","len","ratio"])\n\
+cov.groupby("ref").apply(lambda x: pd.Series({"mean_cov":(x["cov"] * x["count"] / x["len"]).sum(),"perc_cov":(100 - x[x["cov"] == 0]["ratio"].iloc[0]*100 if len(x[x["cov"]==0]) > 0 else 1)})).sort("perc_cov", ascending=False).to_csv("$@", sep="\t")' | python


### PR DESCRIPTION
First unmapped reads are extracted using samtools view and samtools bam2fq.
Those are subsequently mapped to the NCBI viral database using bowtie2.
Afterwards a coverage histogram is constructed with bedtools. A summary
of the bedtools coverage file is produced using python that gives percentage
covered and coverage mean per genome.
