### PR TITLE
Fix #22 Add excel version of alltables

### DIFF
--- a/config.inc
+++ b/config.inc
@@ -93,5 +93,7 @@ JAVA7_BIN = /usr/bin/java
 #JAVA = /usr/bin/java $(JAVA_ARGS)
 
 GET_INSERT_SIZE = $(HOME)/share/usr/bin/getInsertSize.py
+
+ANACONDA_27_ENV = /home/debruiji/share/usr/anaconda-envs/anaconda-2.7
 endif
 CONFIG_INC = true

--- a/excel/mutationSummary.mk
+++ b/excel/mutationSummary.mk
@@ -1,0 +1,22 @@
+include modules/variant_callers/somatic/somaticVariantCaller.inc
+include modules/Makefile.inc
+
+ALLTABLES_HIGH_MODERATE_MUTECT = alltables/allTN.$(call VCF_SUFFIXES,mutect).tab.high_moderate.novel.txt
+ALLTABLES_LOW_MODIFIER_MUTECT = alltables/allTN.$(call VCF_SUFFIXES,mutect).tab.low_modifier.novel.txt
+ALLTABLES_HIGH_MODERATE_STRELKA_VARSCAN = alltables/allTN.strelka_varscan_indels.tab.high_moderate.novel.txt
+ALLTABLES_LOW_MODIFIER_STRELKA_VARSCAN = alltables/allTN.strelka_varscan_indels.tab.low_modifier.novel.txt
+
+mutation_summary: excel/mutation_summary.xlsx
+
+
+excel/mutation_summary.xlsx : $(ALLTABLES_HIGH_MODERATE_MUTECT) $(ALLTABLES_LOW_MODIFIER_MUTECT) $(ALLTABLES_HIGH_MODERATE_STRELKA_VARSCAN) $(ALLTABLES_LOW_MODIFIER_STRELKA_VARSCAN)
+	mkdir -p $(@D); \
+	source $(ANACONDA_27_ENV)/bin/activate $(ANACONDA_27_ENV); \
+	python modules/scripts/tsvToExcel.py $< $@ 'mutect_high_moderate' && \
+	python modules/scripts/tsvToExcel.py $(<<) $@ 'mutect_low_modifier' && \
+	python modules/scripts/tsvToExcel.py $(<<<) $@ 'strelka_varscan_high_moderate' && \
+	python modules/scripts/tsvToExcel.py $(<<<<) $@ 'strelka_varscan_low_modifier' && \
+	python modules/scripts/tsvToExcel.py -c CHROM,POS,TUMOR_SAMPLE,ANN[*].GENE,ANN[*].HGVS_P,ANN[*].EFFECT,TUMOR.AD,NORMAL.AD,TUMOR.DP,NORMAL.DP,chasm_score,dbNSFP_MutationTaster_pred,FATHMM_pred,cancer_gene_census,kandoth,lawrence,hap_insuf,REF,ALT,ANN[*].IMPACT $(<) $@ 'SNV_NONSILENT' && \
+	python modules/scripts/tsvToExcel.py -c CHROM,POS,TUMOR_SAMPLE,ANN[*].GENE,ANN[*].HGVS_P,ANN[*].EFFECT,TUMOR.AD,NORMAL.AD,TUMOR.DP,NORMAL.DP,chasm_score,dbNSFP_MutationTaster_pred,FATHMM_pred,cancer_gene_census,kandoth,lawrence,hap_insuf,REF,ALT,ANN[*].IMPACT $(<<) $@ 'SNV_SILENT' && \
+	python modules/scripts/tsvToExcel.py -c CHROM,POS,TUMOR_SAMPLE,ANN[*].GENE,ANN[*].HGVS_P,ANN[*].EFFECT,TUMOR.AD,NORMAL.AD,TUMOR.DP,NORMAL.DP,chasm_score,dbNSFP_MutationTaster_pred,FATHMM_pred,cancer_gene_census,kandoth,lawrence,hap_insuf,REF,ALT,ANN[*].IMPACT $(<<<) $@ 'INDEL_NONSILENT' && \
+	python modules/scripts/tsvToExcel.py -c CHROM,POS,TUMOR_SAMPLE,ANN[*].GENE,ANN[*].HGVS_P,ANN[*].EFFECT,TUMOR.AD,NORMAL.AD,TUMOR.DP,NORMAL.DP,chasm_score,dbNSFP_MutationTaster_pred,FATHMM_pred,cancer_gene_census,kandoth,lawrence,hap_insuf,REF,ALT,ANN[*].IMPACT $(<<<<) $@ 'INDEL_SILENT'

--- a/scripts/tsvToExcel.py
+++ b/scripts/tsvToExcel.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python
+"""
+Write tsv to excel sheet
+"""
+import argparse
+import pandas as pd
+import os
+from openpyxl import load_workbook
+
+
+def write_to_excel(tsv_file, excel_file, sheet_name, column_names, delimiter, overwrite):
+    df = pd.read_csv(tsv_file, sep=delimiter)
+    if not overwrite and os.path.isfile(excel_file):
+        book = load_workbook(excel_file)
+        writer = pd.ExcelWriter(excel_file, engine='openpyxl')
+        writer.book = book
+        writer.sheets = dict((ws.title, ws) for ws in book.worksheets)
+    else:
+        writer = pd.ExcelWriter(excel_file)
+    if column_names:
+        df.to_excel(writer, sheet_name, columns=column_names, index=False)
+    else:
+        df.to_excel(writer, sheet_name, index=False)
+    if not overwrite and os.path.isfile(excel_file):
+        writer.close()
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__,
+                                        formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("tsv_file", type=str, help="TSV")
+    parser.add_argument("excel_file", type=str, help="Excel output")
+    parser.add_argument("sheet_name", type=str, help="Sheet name")
+    parser.add_argument("-c", "--column_names", type=str, default=None, help="Which columns to write (comma separated)")
+    parser.add_argument("-d", "--delimiter", type=str, default="\t", help="Set delimiter")
+    parser.add_argument("--overwrite", action="store_true", help="Overwrite existing excel")
+    args = parser.parse_args()
+    if args.column_names:
+        column_names = args.column_names.split(",")
+    else:
+        column_names = None
+    write_to_excel(args.tsv_file, args.excel_file, args.sheet_name, column_names, args.delimiter, args.overwrite)
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This adds all the silent (low/modifier) and non silent (moderate/high) indels
from the varscan/strelka intersection and the snvs from mutect in a single
excel sheet. Furthermore there are four separate "view" sheets created that
have just the columns we usually send onwards to our collaborators they are
called {SNV,INDEL}_{SILENT,NON_SILENT}. Only important columns still missing
from those sheets are the TUMOR_MAF and NORMAL_MAF but the columns to compute
that in excel are included (i.e. TUMOR.DP, NORMAL.DP, TUMOR.AD, NORMAL.AD).
