### PR TITLE
Fix #10 Add copy number regulated annotation

### DIFF
--- a/variant_callers/somatic/somaticVariantCaller.inc
+++ b/variant_callers/somatic/somaticVariantCaller.inc
@@ -5,7 +5,7 @@ FFPE_NORMAL_FILTER ?= false
 VALIDATION ?= false
 
 VALIDATION_FILTERS := dbsnp cosmic nsfp eff
-INDEL_ANN_FILTERS := dbsnp cosmic nsfp eff gene_ann
+INDEL_ANN_FILTERS := dbsnp cosmic nsfp eff gene_ann cn_reg
 SNV_ANN_FILTERS := $(INDEL_ANN_FILTERS) chasm fathmm
 # apply depth filter to varscan and mutect
 FILTERS = $(if $(findstring varscan,$1) $(findstring mutect,$1),dp_ft \

--- a/vcf_tools/vcftools.mk
+++ b/vcf_tools/vcftools.mk
@@ -1,7 +1,7 @@
 # vim: set ft=make :
 # sub module containing vcf related tools
 
-#include modules/Makefile.inc
+include modules/Makefile.inc
 #include modules/variant_callers/gatk.inc
 
 ..DUMMY := $(shell mkdir -p version; echo "$(SNP_EFF) &> version/snp_eff.txt")
@@ -296,6 +296,15 @@ KANDOTH_BED = $(HOME)/share/reference/annotation_gene_lists/Kandoth_127genes.bed
 LAWRENCE_BED = $(HOME)/share/reference/annotation_gene_lists/Lawrence_cancer5000-S.bed
 %.gene_ann.vcf : %.vcf
 	$(call LSCRIPT_MEM,8G,12G,"$(ADD_GENE_LIST_ANNOTATION) --genome $(REF) --geneBed $(HAPLOTYPE_INSUF_BED)$(,)$(CANCER_GENE_CENSUS_BED)$(,)$(KANDOTH_BED)$(,)$(LAWRENCE_BED) --name hap_insuf$(,)cancer_gene_census$(,)kandoth$(,)lawrence --outFile $@ $< && $(RM) $< $<.idx")
+
+# Copy number regulated genes annotated per subtype
+# FYI Endometrioid_MSI-L has no copy number regulated genes
+CN_ENDOMETRIAL_SUBTYPES = CN_high CN_low Endometrioid_MSI-H Endometrioid_MSS Endometrioid MSI POLE Serous
+CN_BREAST_SUBTYPES = ER_negative ER_positive HER2_postitive Pam50_Basal Pam50_Her2 Pam50_LumA Pam50_LumB Pam50_Normal Triple_negative
+CN_ENDOMETRIAL_BED = $(foreach set,$(CN_ENDOMETRIAL_SUBTYPES), $(HOME)/share/reference/annotation_gene_lists/cn_reg/endometrial/copy_number_regulated_genes_subtype_$(set)_spearmanrsquare0.4_fdrbh_adjp_lt0.05.HUGO.bed)
+CN_BREAST_BED = $(foreach set,$(CN_BREAST_SUBTYPES), $(HOME)/share/reference/annotation_gene_lists/cn_reg/breast/metabric_subtype_$(set)_copy_number_regulated_genes_std0.5_spearmanrsquare0.4_fdrbh_adjp_lt0.05.HUGO.bed)
+%.cn_reg.vcf : %.vcf
+	$(call LSCRIPT_MEM,8G,12G,"$(ADD_GENE_LIST_ANNOTATION) --genome $(REF) --geneBed $(subst $(space),$(,),$(strip $(CN_ENDOMETRIAL_BED)) $(strip $(CN_BREAST_BED))) --name $(subst $(space),$(,),$(foreach set,$(strip $(CN_ENDOMETRIAL_SUBTYPES)),endometrial_$(set)) $(foreach set,$(strip $(CN_BREAST_SUBTYPES)),breast_$(set))) --outFile $@ $< && $(RM) $< $<.idx")
 
 #-cancer does nothing
 #%.som_eff.vcf : %.vcf %.vcf.pair

--- a/vcf_tools/vcftools.mk
+++ b/vcf_tools/vcftools.mk
@@ -299,7 +299,7 @@ LAWRENCE_BED = $(HOME)/share/reference/annotation_gene_lists/Lawrence_cancer5000
 
 # Copy number regulated genes annotated per subtype
 # FYI Endometrioid_MSI-L has no copy number regulated genes
-CN_ENDOMETRIAL_SUBTYPES = CN_high CN_low Endometrioid_MSI-H Endometrioid_MSS Endometrioid MSI POLE Serous
+CN_ENDOMETRIAL_SUBTYPES = CN_high CN_low Endometrioid_MSI_H Endometrioid_MSS Endometrioid MSI POLE Serous
 CN_BREAST_SUBTYPES = ER_negative ER_positive HER2_postitive Pam50_Basal Pam50_Her2 Pam50_LumA Pam50_LumB Pam50_Normal Triple_negative
 CN_ENDOMETRIAL_BED = $(foreach set,$(CN_ENDOMETRIAL_SUBTYPES), $(HOME)/share/reference/annotation_gene_lists/cn_reg/endometrial/copy_number_regulated_genes_subtype_$(set)_spearmanrsquare0.4_fdrbh_adjp_lt0.05.HUGO.bed)
 CN_BREAST_BED = $(foreach set,$(CN_BREAST_SUBTYPES), $(HOME)/share/reference/annotation_gene_lists/cn_reg/breast/metabric_subtype_$(set)_copy_number_regulated_genes_std0.5_spearmanrsquare0.4_fdrbh_adjp_lt0.05.HUGO.bed)


### PR DESCRIPTION
Add columns for copy number regulated genes of breast and endometrial subtypes
based on analysis in
https://github.com/inodb/notebooks/blob/d1eb829d6a5cec03d2f445aea9f71e80063e4bfc/stats/metabric/copy_number_regulated.ipynb
and
https://github.com/inodb/notebooks/blob/d1eb829d6a5cec03d2f445aea9f71e80063e4bfc/stats/tcga/copy_number_regulation.ipynb.
This adds 17 columns, 9 subtypes for breast and 8 for endometrial with TRUE/.
values similar to the other gene annotations.
