### PR TITLE
Add {non}synonymous, update excel, change rbind

### DIFF
--- a/excel/mutationSummary.mk
+++ b/excel/mutationSummary.mk
@@ -2,14 +2,29 @@ include modules/variant_callers/somatic/somaticVariantCaller.inc
 include modules/Makefile.inc
 
 
-ALLTABLES_HIGH_MODERATE_MUTECT = alltables/allTN.$(call VCF_SUFFIXES,mutect).tab.high_moderate.novel.txt
-ALLTABLES_LOW_MODIFIER_MUTECT = alltables/allTN.$(call VCF_SUFFIXES,mutect).tab.low_modifier.novel.txt
-ALLTABLES_HIGH_MODERATE_STRELKA_VARSCAN = alltables/allTN.strelka_varscan_indels.tab.high_moderate.novel.txt
-ALLTABLES_LOW_MODIFIER_STRELKA_VARSCAN = alltables/allTN.strelka_varscan_indels.tab.low_modifier.novel.txt
+ALLTABLES_HIGH_MODERATE_MUTECT = alltables/allTN.$(call VCF_SUFFIXES,mutect).tab.high_moderate.txt
+ALLTABLES_LOW_MODIFIER_MUTECT = alltables/allTN.$(call VCF_SUFFIXES,mutect).tab.low_modifier.txt
+ALLTABLES_SYNONYMOUS_MUTECT = alltables/allTN.$(call VCF_SUFFIXES,mutect).tab.synonymous.txt
+ALLTABLES_NONSYNONYMOUS_MUTECT = alltables/allTN.$(call VCF_SUFFIXES,mutect).tab.nonsynonymous.txt
+ALLTABLES_HIGH_MODERATE_STRELKA_VARSCAN = alltables/allTN.strelka_varscan_indels.tab.high_moderate.txt
+ALLTABLES_LOW_MODIFIER_STRELKA_VARSCAN = alltables/allTN.strelka_varscan_indels.tab.low_modifier.txt
+ALLTABLES_SYNONYMOUS_STRELKA_VARSCAN = alltables/allTN.strelka_varscan_indels.tab.synonymous.txt
+ALLTABLES_NONSYNONYMOUS_STRELKA_VARSCAN = alltables/allTN.strelka_varscan_indels.tab.nonsynonymous.txt
+
+ABSOLUTE_SOMATIC_TXTS ?= $(foreach sample,$(SAMPLE_SETS),absolute/tables/$(set).somatic.txt)
+ABSOLUTE_SEGMENTS ?= $(foreach sample,$(SAMPLE_SETS),absolute/reviewed/SEG_MAF/$(set)_ABS_MAF.txt
 
 mutation_summary: excel/mutation_summary.xlsx
 
+EXCEL_MERGE_ABSOLUTE ?= false
 
-excel/mutation_summary.xlsx : $(ALLTABLES_HIGH_MODERATE_MUTECT) $(ALLTABLES_LOW_MODIFIER_MUTECT) $(ALLTABLES_HIGH_MODERATE_STRELKA_VARSCAN) $(ALLTABLES_LOW_MODIFIER_STRELKA_VARSCAN)
+
+ifeq ($(EXCEL_MERGE_ABSOLUTE),false)
+excel/mutation_summary.xlsx : $(ALLTABLES_HIGH_MODERATE_MUTECT) $(ALLTABLES_LOW_MODIFIER_MUTECT) $(ALLTABLES_SYNONYMOUS_MUTECT) $(ALLTABLES_NONSYNONYMOUS_MUTECT) $(ALLTABLES_HIGH_MODERATE_STRELKA_VARSCAN) $(ALLTABLES_LOW_MODIFIER_STRELKA_VARSCAN) $(ALLTABLES_SYNONYMOUS_STRELKA_VARSCAN) $(ALLTABLES_NONSYNONYMOUS_STRELKA_VARSCAN)
 	$(INIT) source $(ANACONDA_27_ENV)/bin/activate $(ANACONDA_27_ENV); \
-	python modules/scripts/mutation_summary_excel.py $< $(<<) $(<<<) $(<<<<) $@
+	python modules/scripts/mutation_summary_excel.py $^ $@
+else
+excel/mutation_summary.xlsx : $(ALLTABLES_HIGH_MODERATE_MUTECT) $(ALLTABLES_LOW_MODIFIER_MUTECT) $(ALLTABLES_SYNONYMOUS_MUTECT) $(ALLTABLES_NONSYNONYMOUS_MUTECT) $(ALLTABLES_HIGH_MODERATE_STRELKA_VARSCAN) $(ALLTABLES_LOW_MODIFIER_STRELKA_VARSCAN) $(ALLTABLES_SYNONYMOUS_STRELKA_VARSCAN) $(ALLTABLES_NONSYNONYMOUS_STRELKA_VARSCAN) $(ABSOLUTE_SOMATIC_TXTS) $(ABSOLUTE_SEGMENTS)
+	$(INIT) source $(ANACONDA_27_ENV)/bin/activate $(ANACONDA_27_ENV); \
+	python modules/scripts/mutation_summary_excel.py --absolute_somatic_txts $(subst $(space),$(,),$(strip $(ABSOLUTE_SOMATIC_TXTS))) --absolute_segments $(subst $(space),$(,),$(strip $(ABSOLUTE_SEGMENTS))) $(wordlist 1,8,$^) $@
+endif

--- a/scripts/rbind.R
+++ b/scripts/rbind.R
@@ -16,6 +16,7 @@ arguments <- parse_args(parser, positional_arguments = T);
 opt <- arguments$options;
 files <- arguments$args;
 
+
 Data <- list();
 for (f in files) {
     X <- read.table(file = f, sep = '\t', as.is = T, comment.char = '', quote = '');
@@ -81,6 +82,36 @@ for (f in files) {
     }   
 }
 if (length(Data) == 0) {
+    # print empty table in case there are no mutations
+    f <- files[1]
+    X <- read.table(file = f, sep = '\t', as.is = T, comment.char = '', quote = '')
+    h <- X[1,]
+    h <- sub('#', '', h)
+    colnames(X) <- h
+    X <- X[-1, ]
+    if (opt$sampleName) {
+        X[,"SAMPLE"] <- character(0)
+        h <- c("SAMPLE", h)
+        sname <- sub('\\..*', '', f)
+        sname <- sub('.*/', '', sname)
+        h <- sub(paste(sname, '\\.', sep = ''), 'SAMPLE.', h)
+        colnames(X) <- h
+    }
+    if (opt$tumorNormal) {
+        sname <- sub('\\..*', '', f)
+        sname <- sub('.*/', '', sname)
+        tumor <- sub('_.*', '', sname)
+        normal <- sub('.*_', '', sname)
+        X[,"TUMOR_SAMPLE"] <- character(0)
+        X[,"NORMAL_SAMPLE"] <- character(0)
+        h <- c("TUMOR_SAMPLE", "NORMAL_SAMPLE", h)
+
+        h <- sub(paste(tumor, '\\.', sep = ''), 'TUMOR.', h)
+        h <- sub(paste(normal, '\\.', sep = ''), 'NORMAL.', h)
+        colnames(X) <- h
+    }
+    write.table(X, sep = '\t', row.names = F, quote = F)
+
     quit(save = 'no', status = 0)
 }
 

--- a/variant_callers/gatkVariantCaller.mk
+++ b/variant_callers/gatkVariantCaller.mk
@@ -43,7 +43,7 @@ VPATH ?= bam
 # create novel indel/snp tables
 
 ##### MAIN TARGETS ######
-EFF_TYPES = low_modifier high_moderate
+EFF_TYPES = low_modifier high_moderate synonymous nonsynonymous
 VARIANT_TYPES = gatk_snps gatk_indels
 
 VALIDATION ?= false

--- a/variant_callers/somatic/somaticVariantCaller.inc
+++ b/variant_callers/somatic/somaticVariantCaller.inc
@@ -23,7 +23,7 @@ FILTERS += $(if $(findstring true,$(VALIDATION)),$(VALIDATION_FILTERS),\
 
 FILTER_SUFFIX = $1.$(subst $( ),.,$(strip $(FILTERS)))
 
-EFF_TYPES := high_moderate low_modifier
+EFF_TYPES := high_moderate low_modifier synonymous nonsynonymous
 
 VCF_SUFFIXES = $(foreach type,$1,$(call FILTER_SUFFIX,$(type)))
 

--- a/variant_callers/varscan.mk
+++ b/variant_callers/varscan.mk
@@ -29,7 +29,7 @@ SNP_VCF_EFF_FIELDS += VAF
 INDEL_VCF_EFF_FIELDS += VAF
 
 ANN_TYPES = eff # annotated
-EFF_TYPES = high_moderate low_modifier
+EFF_TYPES = high_moderate low_modifier synonymous nonsynonymous
 VARIANT_TYPES = varscan_snps varscan_indels
 
 MIN_MAP_QUAL ?= 1

--- a/vcf_tools/vcftools.mk
+++ b/vcf_tools/vcftools.mk
@@ -230,18 +230,27 @@ endif
 	col=$$(head -1 $< | tr '\t' '\n' | grep -n "IMPACT" | sed 's/:.*//'); \
 	$(INIT) head -1 $< > $@ && awk -v col=$$col '! (match($$col, /MODERATE/) || match($$col, /HIGH/)) && (match($$col, /LOW/) || match($$col,/MODIFIER/))' $< >> $@
 
-%.nonsilent.txt : %.txt
-	$(INIT) head -1 $< > $@ && sed '1d' $< | grep $(foreach eff,$(NON_SILENT_EFF), -e $(eff)) >> $@ || true
+%.synonymous.txt : %.txt
+	col_imp=$$(head -1 $< | tr '\t' '\n' | grep -n "IMPACT" | sed 's/:.*//'); \
+	col_eff=$$(head -1 $< | tr '\t' '\n' | grep -n "EFFECT" | sed 's/:.*//'); \
+	$(INIT) head -1 $< > $@ && awk -v col_imp=$$col_imp -v col_eff=$$col_eff '! (match($$col_imp, /MODERATE/) || match($$col_imp, /HIGH/)) && (match($$col_imp, /LOW/) && (match($$col_eff, /synonymous_variant/)))' $< >> $@
 
-%.nonsilent_cds.txt : %.txt
-	$(INIT) head -1 $< > $@ && sed '1d' $< | grep $(foreach eff,$(NON_SILENT_CODING_EFF), -e $(eff)) >> $@ || true
+%.nonsynonymous.txt : %.txt
+	col=$$(head -1 $< | tr '\t' '\n' | grep -n "IMPACT" | sed 's/:.*//'); \
+	$(INIT) head -1 $< > $@ && awk -v col=$$col 'match($$col, /MODERATE/) || match($$col, /HIGH/)' $< >> $@
 
-%.missense.txt : %.txt
-	$(INIT) head -1 $< > $@ && sed '1d' $< | grep -e MISSENSE >> $@ || true
-
-%.silent.txt : %.txt
-	$(INIT) head -1 $< > $@ && sed '1d' $< | grep -e SILENT >> $@ || true
-
+# DEPRECATED
+#%.nonsilent.txt : %.txt
+#	$(INIT) head -1 $< > $@ && sed '1d' $< | grep $(foreach eff,$(NON_SILENT_EFF), -e $(eff)) >> $@ || true
+#
+#%.nonsilent_cds.txt : %.txt
+#	$(INIT) head -1 $< > $@ && sed '1d' $< | grep $(foreach eff,$(NON_SILENT_CODING_EFF), -e $(eff)) >> $@ || true
+#
+#%.missense.txt : %.txt
+#	$(INIT) head -1 $< > $@ && sed '1d' $< | grep -e MISSENSE >> $@ || true
+#
+#%.silent.txt : %.txt
+#	$(INIT) head -1 $< > $@ && sed '1d' $< | grep -e SILENT >> $@ || true
 
 # extract vcf to table
 tables/%.opl_tab.txt : vcf/%.vcf


### PR DESCRIPTION
Filter mutations in synonymous and nonsynonymous in addition to the already
existing high_moderate and low_modifier postfixes. All mutations are classified
as nonsynonymous if they have high/moderate impact according to snpeff. The low
impact category ends up in the synonymous category if it is a
synonymous_variant. Note that there are still some nonsynonymous start/stop
mutations in the low impact category that are not included. Also, notice that
by definition {non}synonymous mutations are only in the exon region so all
introns are excluded. The rbind script has been changed to output just the
header for alltables in case there are no mutations.
