### PR TITLE
Add recurrent mutations sufam report

### DIFF
--- a/config.inc
+++ b/config.inc
@@ -33,6 +33,11 @@ MY_RSCRIPT = $(HOME)/share/usr/bin/Rscript-3.1.2
 RSCRIPT = $(MY_RSCRIPT)
 #RSCRIPT = $(HOME)/usr/bin/Rscript
 
+# General python 2.7 environment
+ANACONDA_27_ENV = /home/debruiji/share/usr/anaconda-envs/anaconda-2.7
+# SUFAM python environment
+SUFAM_ENV = /home/debruiji/share/usr/anaconda-envs/sufam-0.4.1
+
 JARDIR := $(HOME)/share/usr/lib/java
 
 ### Applications
@@ -94,8 +99,6 @@ JAVA7_BIN = /usr/bin/java
 #JAVA = /usr/bin/java $(JAVA_ARGS)
 
 GET_INSERT_SIZE = $(HOME)/share/usr/bin/getInsertSize.py
-
-ANACONDA_27_ENV = /home/debruiji/share/usr/anaconda-envs/anaconda-2.7
 
 #GATK
 GATK_JAR = $(JARDIR)/GenomeAnalysisTK.jar

--- a/recurrent_mutations/report.mk
+++ b/recurrent_mutations/report.mk
@@ -27,8 +27,8 @@ recurrent_mutations/sufam/all_mutations.vcf: $(ALLTABLES_NONSYNONYMOUS_MUTECT) $
 
 recurrent_mutations/sufam/%_validated_sufam.txt: recurrent_mutations/sufam/all_mutations.vcf bam/%.bam
 	$(INIT) unset PYTHONPATH && \
-		source /home/debruiji/share/usr/anaconda-envs/sufam-0.4.1/bin/activate \
-			   /home/debruiji/share/usr/anaconda-envs/sufam-0.4.1 && \
+		source $(SUFAM_ENV)/bin/activate \
+			   $(SUFAM_ENV) && \
 		sufam --sample_name $* $(REF_FASTA) $< $(<<) > $@
 
 recurrent_mutations/sufam/all_sufam.txt: $(foreach sample,$(SAMPLES),recurrent_mutations/sufam/$(sample)_validated_sufam.txt)

--- a/recurrent_mutations/report.mk
+++ b/recurrent_mutations/report.mk
@@ -6,9 +6,45 @@ LOGDIR = log/recurrent_mutations.$(NOW)
 ALLTABLES_NONSYNONYMOUS_MUTECT = alltables/allTN.$(call SOMATIC_VCF_SUFFIXES,mutect).tab.nonsynonymous.txt
 ALLTABLES_NONSYNONYMOUS_STRELKA_VARSCAN = alltables/allTN.strelka_varscan_indels.tab.nonsynonymous.txt
 
-recurrent_mutations: recurrent_mutations/recurrent_mutations.tsv
+# sufam plot parameters
+SUFAM_PLOT_MIN_NR_SAMPLES_WITH_MUTATION?=2
+SUFAM_PLOT_SAMPLE_ORDER?=$(SAMPLES)
+
+
+recurrent_mutations: recurrent_mutations/recurrent_mutations.tsv recurrent_mutations/sufam/all_mutations.vcf recurrent_mutations/sufam/all_sufam.txt recurrent_mutations/sufam/sufam.ipynb recurrent_mutations/sufam/sufam.html
 
 recurrent_mutations/recurrent_mutations.tsv: $(ALLTABLES_NONSYNONYMOUS_MUTECT) $(ALLTABLES_NONSYNONYMOUS_STRELKA_VARSCAN)
-	$(INIT) unset PYTHONPATH; \
-	source $(ANACONDA_27_ENV)/bin/activate $(ANACONDA_27_ENV); \
+	$(INIT) unset PYTHONPATH && \
+	source $(ANACONDA_27_ENV)/bin/activate $(ANACONDA_27_ENV) && \
 	python modules/scripts/recurrent_mutations_plot.py $^ $(@D)
+
+recurrent_mutations/sufam/all_mutations.vcf: $(ALLTABLES_NONSYNONYMOUS_MUTECT) $(ALLTABLES_NONSYNONYMOUS_STRELKA_VARSCAN)
+	$(INIT) unset PYTHONPATH && \
+	source $(ANACONDA_27_ENV)/bin/activate $(ANACONDA_27_ENV) && \
+	(csvcut -tc CHROM,POS,ID,REF,ALT,ANN[*].GENE,ANN[*].HGVS_P,ANN[*].IMPACT,ANN[*].EFFECT,GMAF $< | head -1 | sed 's/CHROM/#CHROM/'; \
+	 csvcut -tc CHROM,POS,ID,REF,ALT,ANN[*].GENE,ANN[*].HGVS_P,ANN[*].IMPACT,ANN[*].EFFECT,GMAF $< | tail -n +2 | sort -u; \
+	 csvcut -tc CHROM,POS,ID,REF,ALT,ANN[*].GENE,ANN[*].HGVS_P,ANN[*].IMPACT,ANN[*].EFFECT,GMAF $(<<) | tail -n +2 | sort -u) | csvformat -T > $@
+
+recurrent_mutations/sufam/%_validated_sufam.txt: recurrent_mutations/sufam/all_mutations.vcf bam/%.bam
+	$(INIT) unset PYTHONPATH && \
+		source /home/debruiji/share/usr/anaconda-envs/sufam-0.4.1/bin/activate \
+			   /home/debruiji/share/usr/anaconda-envs/sufam-0.4.1 && \
+		sufam --sample_name $* $(REF_FASTA) $< $(<<) > $@
+
+recurrent_mutations/sufam/all_sufam.txt: $(foreach sample,$(SAMPLES),recurrent_mutations/sufam/$(sample)_validated_sufam.txt)
+	$(INIT) (head -1 $<; tail -qn +2 $^) > $@
+
+recurrent_mutations/sufam/sufam.ipynb: recurrent_mutations/sufam/all_sufam.txt recurrent_mutations/sufam/all_mutations.vcf
+	$(INIT) unset PYTHONPATH && \
+		source $(ANACONDA_27_ENV)/bin/activate $(ANACONDA_27_ENV) && \
+		cd $(@D) && cat ../../modules/scripts/recurrent_mutations_sufam.ipynb | \
+		sed "s:ALL_SUFAM:`basename $<`:" | sed "s:SUFAM_ANNOTATIONS_VCF:`basename $(<<)`:" | sed 's:MIN_NR_SAMPLES_WITH_MUTATION:$(SUFAM_PLOT_MIN_NR_SAMPLES_WITH_MUTATION):' | \
+		sed 's:SAMPLE_ORDER:$(SUFAM_PLOT_SAMPLE_ORDER):' | \
+		runipy --no-chdir - `basename $@`
+
+recurrent_mutations/sufam/sufam.html: recurrent_mutations/sufam/sufam.ipynb
+	$(INIT) unset PYTHONPATH && \
+		source $(ANACONDA_27_ENV)/bin/activate $(ANACONDA_27_ENV) && \
+		ipython nbconvert $< --to html --stdout > $@
+
+.PHONY: recurrent_mutations

--- a/scripts/recurrent_mutations_sufam.ipynb
+++ b/scripts/recurrent_mutations_sufam.ipynb
@@ -1,0 +1,241 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Recurrent non-synonymous mutations as determined by SUFAM"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "import numpy as np\n",
+    "import glob\n",
+    "import os\n",
+    "%matplotlib inline\n",
+    "import seaborn as sns"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "INPUT_FILES = {\n",
+    "    # should be all samples run through sufam on set of all NS mutations in all samples\n",
+    "    \"sufam\":\"ALL_SUFAM\",\n",
+    "    # should be the vcf as supplied to sufam with annotations\n",
+    "    \"ann\":\"SUFAM_ANNOTATIONS_VCF\"\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "PARAMETERS = {\n",
+    "    # should be a number, show only genes/mutations with x number of samples supporting it\n",
+    "    \"min_nr_samples_with_mutation\":int(\"MIN_NR_SAMPLES_WITH_MUTATION\"),\n",
+    "    # should be a list of names\n",
+    "    \"sample_order\":\"SAMPLE_ORDER\".split()\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "df = pd.read_csv(INPUT_FILES[\"sufam\"], dtype={\"chrom\":str}, sep=\"\\t\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "dfa = df.join(pd.read_csv(INPUT_FILES[\"ann\"], dtype={\"#CHROM\":str}, sep=\"\\t\", na_values=\".\")\\\n",
+    "        .drop(\"ID\", axis=1)\\\n",
+    "        .rename(columns={\"#CHROM\":\"chrom\",\n",
+    "                         \"REF\":\"val_ref\",\n",
+    "                         \"ALT\":\"val_alt\",\n",
+    "                         \"POS\":\"pos\"})\\\n",
+    "        .set_index(\"chrom pos val_ref val_alt\".split()),\n",
+    "        on=[\"chrom\",\"pos\",\"val_ref\",\"val_alt\"])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "split = pd.DataFrame(dfa[\"ANN[*].GENE\"].str.split(\"|\").tolist(), index=dfa.index).stack()\n",
+    "split.name = \"GENE_SPLIT\"\n",
+    "split.index = split.index.droplevel(-1)\n",
+    "dfa_split = dfa.join(pd.DataFrame({\"GENE_SPLIT\":split,\n",
+    "              \"IMPACT_SPLIT\":[s for l in dfa[\"ANN[*].IMPACT\"].str.split(\"|\").tolist() for s in l]}, index=split.index))\n",
+    "dfa_split.index = list(range(len(dfa_split)))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Do the samples have NS mutation(s) in the same gene?"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "gene_count = dfa_split[dfa_split[\"IMPACT_SPLIT\"].isin([\"MODERATE\", \"HIGH\"]) & (dfa_split.val_maf > 0)].groupby([\"sample\", \"GENE_SPLIT\"]).chrom.count().unstack(\"sample\").fillna(0)\n",
+    "gene_count = gene_count.reindex_axis(PARAMETERS[\"sample_order\"], axis=1)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "sns.clustermap(gene_count.astype(bool)[gene_count.astype(bool).apply(lambda x: x.sum(), axis = 1) >= PARAMETERS[\"min_nr_samples_with_mutation\"]],\n",
+    "               row_cluster=False, col_cluster=False, figsize=[12, 12])\n",
+    "sns.plt.title(\"Mutation existence in gene\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Do the samples have identical NS mutation(s)?"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "identical_mut_maf = dfa[(dfa[\"ANN[*].IMPACT\"].str.contains(\"MODERATE\") | dfa[\"ANN[*].IMPACT\"].str.contains(\"HIGH\")) & (dfa.val_maf > 0)].groupby([\"sample\", \"chrom\", \"pos\", \"val_ref\", \"val_alt\", \"ANN[*].GENE\", \"ANN[*].HGVS_P\"]).val_maf.max().unstack(\"sample\").fillna(0)\n",
+    "identical_mut_maf = identical_mut_maf.reindex_axis(PARAMETERS[\"sample_order\"], axis=1)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "sns.clustermap(identical_mut_maf.astype(bool)[identical_mut_maf.astype(bool).apply(lambda x: x.sum(), axis = 1) >= PARAMETERS[\"min_nr_samples_with_mutation\"]], \n",
+    "               row_cluster=False, col_cluster=False, figsize=[12, 12])\n",
+    "sns.plt.title(\"Mutation existence\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## What is the MAF of the identical NS mutation(s)?"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "sns.clustermap(identical_mut_maf[identical_mut_maf.astype(bool).apply(lambda x: x.sum(), axis = 1) >= PARAMETERS[\"min_nr_samples_with_mutation\"]],\n",
+    "               row_cluster=False, col_cluster=False, figsize=[12, 12], annot=True)\n",
+    "sns.plt.title(\"MAF per mutation\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## What is the max MAF of each gene with NS mutation(s)?"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "gene_max_maf = dfa_split[dfa_split[\"IMPACT_SPLIT\"].isin([\"MODERATE\", \"HIGH\"]) & (dfa_split.val_maf > 0)].groupby([\"sample\", \"GENE_SPLIT\"]).val_maf.max().unstack(\"sample\").fillna(0)\n",
+    "gene_max_maf = gene_max_maf.reindex_axis(PARAMETERS[\"sample_order\"], axis=1)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "sns.clustermap(gene_max_maf[gene_max_maf.astype(bool).apply(lambda x: x.sum(), axis = 1) >= PARAMETERS[\"min_nr_samples_with_mutation\"]],\n",
+    "               row_cluster=False, col_cluster=False, figsize=[12, 12], annot=True)\n",
+    "sns.plt.title(\"Max mutation MAF per gene\")"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 2",
+   "language": "python",
+   "name": "python2"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 2
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython2",
+   "version": "2.7.11"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
+}


### PR DESCRIPTION
Run sufam on the set of all NS mutations over all samples and generate an
ipython notebook report that shows the maf of each recurrent mutation. Plots
are generated for a mutation at the gene level and an identical mutation in
multiple samples. Parameters for the plots can be set by changing config.inc.
At the moment one can choose in how many samples the mutation must occur and
which samples and in what order they should be plotted.
