### PR TITLE
Add single CCF plot with annotations

### DIFF
--- a/recurrent_mutations/report.mk
+++ b/recurrent_mutations/report.mk
@@ -13,6 +13,8 @@ SUFAM_PLOT_SAMPLE_ORDER?=$(SAMPLES)
 
 recurrent_mutations: recurrent_mutations/recurrent_mutations.tsv recurrent_mutations/sufam/all_mutations.vcf recurrent_mutations/sufam/all_sufam.txt recurrent_mutations/sufam/sufam.ipynb recurrent_mutations/sufam/sufam.html
 
+recurrent_mutations_sufam: recurrent_mutations/sufam/all_mutations.vcf recurrent_mutations/sufam/all_sufam.txt recurrent_mutations/sufam/sufam.ipynb recurrent_mutations/sufam/sufam.html
+
 recurrent_mutations/recurrent_mutations.tsv: $(EXCEL_NONSYNONYMOUS_MUTECT) $(EXCEL_NONSYNONYMOUS_STRELKA_VARSCAN)
 	$(INIT) unset PYTHONPATH && \
 	source $(ANACONDA_27_ENV)/bin/activate $(ANACONDA_27_ENV) && \


### PR DESCRIPTION
For the recurrent_mutations report, generate a single CCF plot with everything
combined i.e. LOH, Cancer genes, clonality. Updated the wiki accordingly as
well. Change the styling of the CCF plot per case to use a blue gradient scale,
which is more similar to the orignal R plots.
