### PR TITLE
fix #196

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -386,4 +386,12 @@ TARGETS += strelka_varscan_indels
 strelka_varscan_indels:
 	$(call RUN_MAKE,modules/variant_callers/somatic/strelkaVarscanIndels.mk)
 
+TARGETS += ann_somatic_vcf
+ann_somatic_vcf: 
+	$(call RUN_MAKE,modules/vcf_tools/annotateSomaticVcf.mk)
+
+TARGETS += ann_vcf
+ann_vcf: 
+	$(call RUN_MAKE,modules/vcf_tools/annotateVcf.mk)
+
 .PHONY : $(TARGETS)

--- a/variant_callers/gatkVariantCaller.mk
+++ b/variant_callers/gatkVariantCaller.mk
@@ -17,7 +17,6 @@ LOGDIR ?= log/gatk.$(NOW)
 ##### MAKE INCLUDES #####
 include modules/Makefile.inc
 include modules/variant_callers/gatk.inc
-include modules/variant_callers/variantCaller.inc
 
 VPATH ?= bam
 
@@ -44,15 +43,13 @@ VPATH ?= bam
 ##### MAIN TARGETS ######
 VARIANT_TYPES = gatk_snps gatk_indels
 
-PHONY += gatk gatk_vcfs gatk_mafs gatk_reports
+PHONY += gatk gatk_vcfs gatk_mafs
 
-gatk : gatk_vcfs gatk_mafs # reports
+gatk : gatk_vcfs #gatk_mafs reports
 
-$(foreach type,$(VARIANT_TYPES),$(eval $(call merged-vcf,$(type))))
-gatk_vcfs : $(foreach type,$(VARIANT_TYPES),$(call VCFS,$(type)) $(addsuffix .idx,$(call VCFS,$(type))))
-gatk_mafs : $(foreach type,$(VARIANT_TYPES),$(call MAFS,$(type)))
+gatk_vcfs : $(foreach type,$(VARIANT_TYPES),$(foreach sample,$(SAMPLES),vcf/$(sample).$(type).vcf))
+gatk_mafs : $(foreach type,$(VARIANT_TYPES),$(foreach sample,$(SAMPLES),maf/$(sample).$(type).maf))
 
-gatk_reports : $(foreach type,gatk_indels gatk_snps,reports/$(type).dp_ft.grp)
 
 include modules/variant_callers/gatk.mk
 

--- a/variant_callers/hotspot.mk
+++ b/variant_callers/hotspot.mk
@@ -20,13 +20,7 @@ hotspot_vcfs : $(if $(SAMPLE_PAIRS),\
 hotspot_tables : $(if $(SAMPLE_PAIRS),alltables/allTN.hotspot.tab.txt\
 	alltables/all.hotspot.tab.txt)
 
-vcf_ann/%.hotspot.vcf : vcf/ann/%.hotspot.vcf
-	$(INIT) cp $< $@
-
-vcf/ft/%.hotspot.vcf : vcf/ft/ac_ft/%.hotspot.ac_ft.vcf
-	$(INIT) cp $< $@
-
-vcf/ann/%.hotspot.vcf : vcf/ann/hotspot_ann/%.hotspot.hotspot_ann.vcf
+vcf_ann/%.hotspot.vcf : vcf/%.hotspot.ac_ft.hotspot_ann.vcf
 	$(INIT) cp $< $@
 
 vcf/%.hotspot.vcf : $(foreach i,$(HOTSPOT_VCF_SEQ),hotspot/%.hotspot.$i.vcf.gz hotspot/%.hotspot.$i.vcf.gz.tbi)

--- a/variant_callers/somatic/mutectVariantCaller.mk
+++ b/variant_callers/somatic/mutectVariantCaller.mk
@@ -10,14 +10,10 @@ mutect : mutect_vcfs ext_output # mutect_mafs
 
 include modules/variant_callers/somatic/mutect.mk
 include modules/variant_callers/somatic/mutect.inc
-include modules/variant_callers/somatic/somaticVariantCaller.inc
 
 ..DUMMY := $(shell mkdir -p version; echo "$(MUTECT) &> version/mutect.txt")
 
-$(eval $(call somatic-merged-vcf,mutect))
-
-mutect_vcfs : $(call SOMATIC_VCFS,mutect)
-#mutect_mafs : $(call SOMATIC_MAFS,mutect)
+mutect_vcfs : $(foreach pair,$(SOMATIC_PAIRS),vcf/$(pair).mutect.vcf)
 ext_output : $(foreach pair,$(SAMPLE_PAIRS),mutect/tables/$(pair).mutect.txt)
 mut_report : mutect/report/index.html mutect/lowAFreport/index.html mutect/highAFreport/index.html
 

--- a/variant_callers/somatic/scalpel.mk
+++ b/variant_callers/somatic/scalpel.mk
@@ -4,7 +4,6 @@
 include modules/Makefile.inc
 include modules/variant_callers/gatk.inc
 include modules/variant_callers/somatic/scalpel.inc
-include modules/variant_callers/somatic/somaticVariantCaller.inc
 
 LOGDIR = log/scalpel.$(NOW)
 
@@ -12,15 +11,13 @@ LOGDIR = log/scalpel.$(NOW)
 
 .SECONDARY:
 .DELETE_ON_ERROR:
-.PHONY: all scalpel_vcfs scalpel_tables scalpel_mafs
+.PHONY: all scalpel_vcfs scalpel_mafs
 
-scalpel : scalpel_vcfs scalpel_tables scalpel_mafs
+scalpel : scalpel_vcfs scalpel_mafs
 
-$(eval $(call somatic-merged-vcf,scalpel_indels))
 
-scalpel_vcfs : $(call SOMATIC_VCFS,scalpel_indels)
-scalpel_mafs : $(call SOMATIC_MAFS,scalpel_indels)
-scalpel_tables : $(call SOMATIC_TABLES,scalpel_indels)
+scalpel_vcfs : $(foreach pair,$(SAMPLE_PAIR),vcf/$(pair).scalpel_indels.vcf)
+scalpel_mafs : $(foreach pair,$(SAMPLE_PAIR),maf/$(pair).scalpel_indels.maf)
 
 ifdef BED_FILES
 define scalpel-bed-tumor-normal

--- a/variant_callers/somatic/strelka.mk
+++ b/variant_callers/somatic/strelka.mk
@@ -13,9 +13,8 @@ PHONY += strelka strelka_vcfs strelka_mafs
 strelka : strelka_vcfs #strelka_mafs
 	
 VARIANT_TYPES := strelka_snps strelka_indels
-$(foreach type,$(VARIANT_TYPES),$(eval $(call somatic-merged-vcf,$(type))))
-strelka_vcfs : $(foreach type,$(VARIANT_TYPES),$(call SOMATIC_VCFS,$(type)))
-strelka_mafs : $(foreach type,$(VARIANT_TYPES),$(call SOMATIC_MAFS,$(type)))
+strelka_vcfs : $(foreach type,$(VARIANT_TYPES),$(foreach pair,$(SAMPLE_PAIRS),vcf/$(pair).$(type).vcf))
+strelka_mafs : $(foreach type,$(VARIANT_TYPES),$(foreach pair,$(SAMPLE_PAIRS),maf/$(pair).$(type).maf))
 
 define strelka-tumor-normal
 strelka/$1_$2/Makefile : bam/$1.bam bam/$2.bam

--- a/variant_callers/somatic/strelkaVarscanIndels.mk
+++ b/variant_callers/somatic/strelkaVarscanIndels.mk
@@ -1,16 +1,15 @@
 # Run VarScan and strelka on tumour-normal matched pairs for indels
 #
 include modules/Makefile.inc
-include modules/variant_callers/somatic/somaticVariantCaller.inc
 LOGDIR = log/strelkaVarscan.$(NOW)
 
 
 .PHONY : strelka_varscan_merge_vcfs strelka_varscan_merge
 strelka_varscan_merge : strelka_varscan_merge_vcfs 
-strelka_varscan_merge_vcfs : $(foreach pair,$(SAMPLE_PAIRS),vcf_ann/$(pair).strelka_varscan_indels.vcf)
+strelka_varscan_merge_vcfs : $(foreach pair,$(SAMPLE_PAIRS),vcf/$(pair).strelka_varscan_indels.vcf)
 #strelka_varscan_merge_mafs : $(foreach pair,$(SAMPLE_PAIRS),maf/$(pair).strelka_varscan_indels.vcf)
 
-vcf_ann/%.strelka_varscan_indels.vcf : vcf_ann/%.varscan_indels.vcf vcf_ann/%.strelka_indels.vcf
+vcf/%.strelka_varscan_indels.vcf : vcf/%.varscan_indels.vcf vcf/%.strelka_indels.vcf
 	$(call LSCRIPT_MEM,9G,12G,"grep -P '^#' $< > $@ && $(BEDTOOLS) intersect -a $< -b $(<<) >> $@")
 
 

--- a/variant_callers/somatic/varscanTN.mk
+++ b/variant_callers/somatic/varscanTN.mk
@@ -6,7 +6,6 @@ LOGDIR ?= log/varscanTN.$(NOW)
 
 ##### MAKE INCLUDES #####
 include modules/Makefile.inc
-include modules/variant_callers/somatic/somaticVariantCaller.inc
 
 IGNORE_FP_FILTER ?= true
 
@@ -27,9 +26,8 @@ VARIANT_TYPES = varscan_indels varscan_snps
 
 PHONY += varscan varscan_vcfs varscan_mafs
 varscan : varscan_vcfs #varscan_mafs
-$(foreach type,$(VARIANT_TYPES),$(eval $(call somatic-merged-vcf,$(type))))
-varscan_vcfs : $(foreach type,$(VARIANT_TYPES),$(call SOMATIC_VCFS,$(type)))
-#varscan_mafs : $(foreach type,$(VARIANT_TYPES),$(call SOMATIC_MAFS,$(type)))
+varscan_vcfs : $(foreach type,$(VARIANT_TYPES),$(foreach pair,$(SAMPLE_PAIRS),vcf/$(pair).$(type).vcf))
+varscan_mafs : $(foreach type,$(VARIANT_TYPES),$(foreach pair,$(SAMPLE_PAIRS),maf/$(pair).$(type).maf))
 
 
 %.Somatic.txt : %.txt

--- a/variant_callers/varscan.mk
+++ b/variant_callers/varscan.mk
@@ -52,40 +52,11 @@ override VARSCAN_OPTS = --min-coverage $(VARSCAN_MIN_COVERAGE) \
 	--p-value $(VARSCAN_P_VALUE) \
 	--strand-filter $(VARSCAN_STRAND_FILTER) 
 
-FILTER_SUFFIX := dp_ft.dgd_ft.encode_ft.nft
-ifdef TARGETS_FILE
-FILTER_SUFFIX := $(FILTER_SUFFIX).target_ft
-endif
-ANN_SUFFIX := pass.dbsnp.cosmic.nsfp.eff
+VARIANT_TYPES = varscan_snps varscan_indels
+VCFS = $(foreach sample,$(SAMPLES),$(foreach type,$(VARIANT_TYPES),vcf/$(sample).$(type).vcf))
 
-ifeq ($(VALIDATION),true)
-VCF_SUFFIX.varscan_snps := $(FILTER_SUFFIX).$(ANN_SUFFIX)
-VCF_SUFFIX.varscan_indels := $(FILTER_SUFFIX).$(ANN_SUFFIX)
-else
-VCF_SUFFIX.varscan_snps := $(FILTER_SUFFIX).$(ANN_SUFFIX).chasm.fathmm
-VCF_SUFFIX.varscan_indels := $(FILTER_SUFFIX).$(ANN_SUFFIX)
-endif
-
-ifeq ($(HRUN),true)
-HRUN_FILTER ?= 1
-VCF_SUFFIX.varscan_indels := $(VCF_SUFFIX.varscan_indels).hrun.hrun_ft
-endif
-
-VCF_SUFFIXES = $(foreach type,$(VARIANT_TYPES),$(type).$(VCF_SUFFIX.$(type)))
-TABLE_SUFFIXES = $(foreach suff,$(VCF_SUFFIXES),$(suff).tab.novel $(suff).tab \
-				 $(foreach eff,$(EFF_TYPES),\
-				 $(suff).tab.$(eff).novel $(suff).tab.$(eff)))
-
-VCFS = $(foreach sample,$(SAMPLES),$(foreach suff,$(VCF_SUFFIXES),vcf/$(sample).$(suff).vcf))
-TABLES = $(foreach sample,$(SAMPLES),$(foreach suff,$(TABLE_SUFFIXES),tables/$(sample).$(suff).txt))
-ALLTABLES = $(foreach suff,$(TABLE_SUFFIXES),alltables/all.$(suff).txt)
-
-all : vcfs tables cnv
-variants : vcfs tables
-cnv : copycalls segments
+all : vcfs
 vcfs : $(VCFS)
-tables : $(TABLES) $(ALLTABLES)
-reports : $(foreach type,$(VARIANT_TYPES),reports/$(type).$(FILTER_SUFFIX).grp)
 
 
 ifeq ($(SPLIT_CHR),true)

--- a/vcf_tools/annotateVcf.mk
+++ b/vcf_tools/annotateVcf.mk
@@ -1,4 +1,8 @@
-ifndef VARIANT_CALLER_INC
+include modules/Makefile.inc
+
+LOGDIR ?= log/annotate_vcf.$(NOW)
+override VARIANT_TYPES = gatk_snps gatk_indels
+
 DEPTH_FILTER ?= 5
 HRUN ?= false
 VALIDATION ?= false
@@ -20,36 +24,46 @@ FILTERS += $(if $(findstring indel,$1),\
 
 #POST_FILTERS += cft common_ft
 
+PHONY += all vcfs mafs
+all : vcfs mafs
+vcfs : $(foreach type,$(VARIANT_TYPES),$(type)_vcfs)
+mafs : $(foreach type,$(VARIANT_TYPES),$(type)_mafs)
 
 
 MERGE_VCF = $(PYTHON) modules/vcf_tools/merge_vcf.py
 MERGE_SCRIPT = $(call LSCRIPT_MEM,6G,7G,"$(MERGE_VCF) --out_file $@ $^")
 define merged-vcf
 # first filter round
-vcf/ft/%.$1.ft.vcf : $$(foreach ft,$$(call FILTERS,$1),vcf/ft/$$(ft)/%.$1.$$(ft).vcf)
+vcf/%.$1.ft.vcf : $$(foreach ft,$$(call FILTERS,$1),vcf/%.$1.$$(ft).vcf)
 	$$(MERGE_SCRIPT)
 # first annotation round
-vcf/ann/%.$1.ann.vcf : $$(foreach ann,$$(call ANNOTATIONS,$1),vcf/ann/$$(ann)/%.$1.ft.$$(ann).vcf)
+vcf/%.$1.ann.vcf : $$(foreach ann,$$(call ANNOTATIONS,$1),vcf/%.$1.ft.$$(ann).vcf)
 	$$(MERGE_SCRIPT)
 # post-filter after first annotation round
 ifdef POST_FILTERS
-vcf/ft2/%.$1.ft2.vcf : $$(foreach ft,$$(call POST_FILTERS,$1),vcf/ft2/$$(ft)/%.$1.ann.$$(ft).vcf)
+vcf/%.$1.ft2.vcf : $$(foreach ft,$$(call POST_FILTERS,$1),vcf/%.$1.ann.$$(ft).vcf)
 	$$(MERGE_SCRIPT)
 else
-vcf/ft2/%.$1.ft2.vcf: vcf/ann/%.$1.ann.vcf
+vcf/%.$1.ft2.vcf: vcf/%.$1.ann.vcf
 	$$(INIT) cp $$< $$@
 endif
 # post-filter after first annotation round
 ifdef POST_ANNS
-vcf_ann/%.$1.vcf : $$(foreach ann,$$(call POST_ANNS,$1),vcf/ann2/$$(ann)/%.$1.ft2.$$(ann).vcf)
+vcf_ann/%.$1.vcf : $$(foreach ann,$$(call POST_ANNS,$1),vcf/%.$1.ft2.$$(ann).vcf)
 	$$(MERGE_SCRIPT)
 else
-vcf_ann/%.$1.vcf: vcf/ft2/%.$1.ft2.pass.vcf
+vcf_ann/%.$1.vcf: vcf/%.$1.ft2.pass.vcf
 	$$(INIT) cp $$< $$@
 endif
-endef
-VCFS = $(foreach pair,$(SAMPLE_PAIRS),vcf_ann/$(pair).$1.vcf)
-MAFS = $(foreach pair,$(SAMPLE_PAIRS),maf/$(pair).$1.maf)
-
 endif
-VARIANT_CALLER_INC = true
+PHONY += $1_vcfs $1_mafs
+$1_vcfs : $(foreach sample,$(SAMPLES),vcf_ann/$(sample).$1.vcf)
+$1_mafs : $(foreach sample,$(SAMPLES),vcf_ann/$(sample).$1.maf)
+endef
+$(foreach type,$(VARIANT_TYPES),$(eval $(call merged-vcf,$(type))))
+
+.DELETE_ON_ERROR:
+.SECONDARY:
+.PHONY: $(PHONY) 
+
+include modules/vcf_tools/vcftools.mk

--- a/vcf_tools/vcfAnnotations.mk
+++ b/vcf_tools/vcfAnnotations.mk
@@ -1,43 +1,43 @@
 # dbsnp annotations
-vcf/ann/dbsnp/%.dbsnp.vcf : vcf/ft/%.vcf vcf/ft/%.vcf.idx 
+vcf/%.dbsnp.vcf : vcf/%.vcf vcf/%.vcf.idx 
 	$(call CHECK_VCF,$(call LSCRIPT_CHECK_MEM,9G,12G,"$(call SNP_SIFT_MEM,8G) annotate \
 		$(SNP_SIFT_OPTS) $(DBSNP) $< > $@"))
 
-vcf/ann/hotspot_ann/%.hotspot_ann.vcf : vcf/ft/%.vcf
+vcf/%.hotspot_ann.vcf : vcf/%.vcf
 	$(call CHECK_VCF,$(call LSCRIPT_CHECK_MEM,9G,12G,"$(call SNP_SIFT_MEM,8G) annotate $(SNP_SIFT_OPTS) \
 		$(HOTSPOT_UNMERGED_VCF) $< > $@"))
 
 # mouse genome project dbsnp
-vcf/ann/mgp_dbsnp/%.mgp_dbsnp.vcf : vcf/ft/%.vcf vcf/ft/%.vcf.idx 
+vcf/%.mgp_dbsnp.vcf : vcf/%.vcf vcf/%.vcf.idx 
 	$(call CHECK_VCF,$(call LSCRIPT_CHECK_MEM,33G,65G,"$(call SNP_SIFT_MEM,45G) annotate \
 		-tabix $(SNP_SIFT_OPTS) $(MGP_SNP_DBSNP) $< | $(call SNP_SIFT_MEM,10G) annotate \
 		-tabix $(SNP_SIFT_OPTS) $(MGP_INDEL_DBSNP) > $@"))
 
-vcf/ann/cosmic/%.cosmic.vcf : vcf/ft/%.vcf vcf/ft/%.vcf.idx 
+vcf/%.cosmic.vcf : vcf/%.vcf vcf/%.vcf.idx 
 	$(call CHECK_VCF,$(call LSCRIPT_CHECK_MEM,9G,12G,"$(call SNP_SIFT_MEM,8G) annotate $(SNP_SIFT_OPTS) \
 		$(COSMIC) $< > $@"))
 
 TRANSFIC = $(RSCRIPT) modules/vcf_tools/transficVcf.R
 TRANSFIC_PERL_SCRIPT = $(HOME)/share/usr/transfic/bin/transf_scores.pl
-vcf/ann/transfic/%.transfic.vcf : vcf/ft/%.vcf
+vcf/%.transfic.vcf : vcf/%.vcf
 	$(call CHECK_VCF,$(call LSCRIPT_MEM,9G,12G,"$(TRANSFIC) --genome $(REF) --transfic $(TRANSFIC_PERL_SCRIPT) --outFile $@ $<")
 
 # add exon distance
-vcf/ann/exondist/%.exondist.vcf : vcf/ft/%.vcf
+vcf/%.exondist.vcf : vcf/%.vcf
 	$(call LSCRIPT_CHECK_MEM,2G,3G,"$(INTRON_POSN_LOOKUP) $< > $@")
 
 # run snp eff
 SNP_EFF_FLAGS ?= -canon # -ud 0  -no-intron -no-intergenic -no-utr
 SNP_EFF_OPTS = -c $(SNP_EFF_CONFIG) -i vcf -o vcf $(SNP_EFF_FLAGS)
-vcf/ann/eff/%.eff.vcf : vcf/ft/%.vcf vcf/ft/%.vcf.idx
+vcf/%.eff.vcf : vcf/%.vcf vcf/%.vcf.idx
 	$(call CHECK_VCF,$(call LSCRIPT_CHECK_MEM,9G,14G,"$(call SNP_EFF_MEM,8G) ann $(SNP_EFF_OPTS) $(SNP_EFF_GENOME) -s $(@D)/$*.eff_summary.html $< > $@"))
 
 
-vcf/ann/clinvar/%.clinvar.vcf : vcf/ft/%.vcf vcf/ft/%.vcf.idx 
+vcf/%.clinvar.vcf : vcf/%.vcf vcf/%.vcf.idx 
 	$(call CHECK_VCF,$(call LSCRIPT_CHECK_MEM,9G,12G,"$(call SNP_SIFT_MEM,8G) annotate $(SNP_SIFT_OPTS) \
 		$(CLINVAR) $< > $@"))
 
-vcf/ann/exac_nontcga/%.exac_nontcga.vcf : vcf/ft/%.vcf vcf/ft/%.vcf.idx 
+vcf/exac_nontcga/%.exac_nontcga.vcf : vcf/%.vcf vcf/%.vcf.idx 
 	$(call CHECK_VCF,$(call LSCRIPT_CHECK_MEM,9G,12G,"$(call SNP_SIFT_MEM,8G) annotate $(SNP_SIFT_OPTS) \
 		-info ExAC_AF $(EXAC_NONTCGA) $< > $@"))
 
@@ -47,7 +47,7 @@ KANDOTH_BED = $(HOME)/share/reference/annotation_gene_lists/Kandoth_127genes.bed
 LAWRENCE_BED = $(HOME)/share/reference/annotation_gene_lists/Lawrence_cancer5000-S.bed
 
 ADD_GENE_LIST_ANNOTATION = $(RSCRIPT) modules/vcf_tools/addGeneListAnnotationToVcf.R
-vcf/ann/gene_ann/%.gene_ann.vcf : vcf/ft/%.vcf
+vcf/%.gene_ann.vcf : vcf/%.vcf
 	$(call CHECK_VCF,$(call LSCRIPT_CHECK_MEM,8G,12G,"$(ADD_GENE_LIST_ANNOTATION) --genome $(REF) --geneBed $(HAPLOTYPE_INSUF_BED)$(,)$(CANCER_GENE_CENSUS_BED)$(,)$(KANDOTH_BED)$(,)$(LAWRENCE_BED) --name hap_insuf$(,)cancer_gene_census$(,)kandoth$(,)lawrence --outFile $@ $<"))
 
 # Copy number regulated genes annotated per subtype
@@ -56,12 +56,12 @@ CN_ENDOMETRIAL_SUBTYPES = CN_high CN_low Endometrioid_MSI_H Endometrioid_MSS End
 CN_BREAST_SUBTYPES = ER_negative ER_positive HER2_postitive Pam50_Basal Pam50_Her2 Pam50_LumA Pam50_LumB Pam50_Normal Triple_negative
 CN_ENDOMETRIAL_BED = $(foreach set,$(CN_ENDOMETRIAL_SUBTYPES), $(HOME)/share/reference/annotation_gene_lists/cn_reg/endometrial/copy_number_regulated_genes_subtype_$(set)_spearmanrsquare0.4_fdrbh_adjp_lt0.05.HUGO.bed)
 CN_BREAST_BED = $(foreach set,$(CN_BREAST_SUBTYPES), $(HOME)/share/reference/annotation_gene_lists/cn_reg/breast/metabric_subtype_$(set)_copy_number_regulated_genes_std0.5_spearmanrsquare0.4_fdrbh_adjp_lt0.05.HUGO.bed)
-vcf/ann/cn_reg/%.cn_reg.vcf : vcf/ft/%.vcf
+vcf/%.cn_reg.vcf : vcf/%.vcf
 	$(call CHECK_VCF,$(call LSCRIPT_MEM,8G,12G,"$(ADD_GENE_LIST_ANNOTATION) --genome $(REF) --geneBed $(subst $(space),$(,),$(strip $(CN_ENDOMETRIAL_BED)) $(strip $(CN_BREAST_BED))) --name $(subst $(space),$(,),$(foreach set,$(strip $(CN_ENDOMETRIAL_SUBTYPES)),endometrial_$(set)) $(foreach set,$(strip $(CN_BREAST_SUBTYPES)),breast_$(set))) --outFile $@ $<"))
 
 
 define ad-tumor-normal
-vcf/ann/ad/$1_$2.%.ad.vcf : vcf/ft/$1_$2.%.vcf bam/$1.bam bam/$2.bam bam/$1.bai bam/$2.bai
+vcf/$1_$2.%.ad.vcf : vcf/$1_$2.%.vcf bam/$1.bam bam/$2.bam bam/$1.bai bam/$2.bai
 	$$(call LSCRIPT_CHECK_PARALLEL_MEM,4,2G,3G,"$$(call GATK_MEM,8G) -T VariantAnnotator -nt 4 -R $$(REF_FASTA) -A DepthPerAlleleBySample --dbsnp $$(DBSNP) $$(foreach bam,$$(filter %.bam,$$^),-I $$(bam) ) -V $$< -o $$@ -L $$<")
 endef
 $(foreach pair,$(SAMPLE_PAIRS),\
@@ -71,5 +71,5 @@ ANNOVAR = $(PERL) $(HOME)/share/usr/annovar/table_annovar.pl
 ANNOVAR_PROTOCOL ?= refGene$(,)cytoBand$(,)genomicSuperDups$(,)esp6500siv2_all$(,)1000g2014oct_all$(,)1000g2014oct_afr$(,)1000g2014oct_eas$(,)1000g2014oct_eur$(,)snp138$(,)ljb26_all
 ANNOVAR_OPERATION ?= g$(,)r$(,)r$(,)f$(,)f$(,)f$(,)f$(,)f$(,)f$(,)f
 ANNOVAR_OPTS = --dot2underline -remove -protocol $(ANNOVAR_PROTOCOL) -operation $(ANNOVAR_OPERATION) -nastring . -vcfinput -buildver $(ANNOVAR_REF)
-vcf/annovar/%.$(ANNOVAR_REF)_multianno.vcf : vcf/%.vcf
+vcf/%.$(ANNOVAR_REF)_multianno.vcf : vcf/%.vcf
 	$(call LSCRIPT_CHECK_MEM,7G,9G,"$(ANNOVAR) -out $* $(ANNOVAR_OPTS) $< $(ANNOVAR_DB)")

--- a/vcf_tools/vcfFilters.mk
+++ b/vcf_tools/vcfFilters.mk
@@ -1,53 +1,53 @@
 DEPTH_FILTER ?= 5
 
 FALSE_POSITIVE_BED = $(HOME)/share/reference/fuentes_blacklist.include_cosmic.hg19.bed
-vcf/ft/fp_ft/%.fp_ft.vcf : vcf/%.vcf
+vcf/%.fp_ft.vcf : vcf/%.vcf
 	$(call LSCRIPT_MEM,8G,12G,"$(call GATK_MEM,8G) -T VariantFiltration -R $(REF_FASTA) -V $< -o $@ --maskName 'FuentesFalsePositive' --mask $(FALSE_POSITIVE_BED)")
 
 DGD_BED = $(HOME)/share/reference/dgd.include_cosmic.hg19.bed
-vcf/ft/dgd_ft/%.dgd_ft.vcf : vcf/dgd_ft/%.vcf
+vcf/%.dgd_ft.vcf : vcf/%.vcf
 	$(call LSCRIPT_MEM,8G,12G,"$(call GATK_MEM,8G) -T VariantFiltration -R $(REF_FASTA) -V $< -o $@ --maskName 'DuplicateGenesDB' --mask $(DGD_BED)")
 
 ENCODE_BED = $(HOME)/share/reference/wgEncodeDacMapabilityConsensusExcludable.include_cosmic.bed
-vcf/ft/encode_ft/%.encode_ft.vcf : vcf/%.vcf
+vcf/%.encode_ft.vcf : vcf/%.vcf
 	$(call LSCRIPT_MEM,8G,12G,"$(call GATK_MEM,8G) -T VariantFiltration -R $(REF_FASTA) -V $< -o $@ --maskName 'encode' --mask $(ENCODE_BED)")
 
 %.het_ft.vcf : %.vcf
 	$(call LSCRIPT_MEM,8G,12G,"$(call GATK_MEM,8G) -T VariantFiltration -R $(REF_FASTA) -V $< -o $@ \
 		--genotypeFilterExpression 'isHet == 1' --genotypeFilterName 'Heterozygous positions'")
 
-vcf/ft/dbsnp_ft/%.dbsnp_ft.vcf : vcf/%.vcf
+vcf/%.dbsnp_ft.vcf : vcf/%.vcf
 	$(INIT) awk '/^#/ || $$3 ~ /^rs/ {print}' $< > $@
 
 # apply overall depth filter
-vcf/ft/dp_ft/%.dp_ft.vcf : vcf/%.vcf
+vcf/%.dp_ft.vcf : vcf/%.vcf
 	$(call LSCRIPT_CHECK_MEM,8G,12G,"$(call GATK_MEM,8G) -T VariantFiltration -R $(REF_FASTA) -V $< -o $@ \
 		--filterExpression 'DP < $(DEPTH_FILTER)' --filterName Depth")
 
-%.sdp_ft.vcf : %.vcf
+vcf/%.sdp_ft.vcf : vcf/%.vcf
 	$(call CHECK_VCF,$(call LSCRIPT_CHECK_MEM,2G,5G,"$(call SNP_SIFT_MEM,2G) filter $(SNP_SIFT_OPTS) \
 		-f $< '(exists GEN[*].DP) & (GEN[*].DP > 20)' > $@"))
 
 # apply HRun filter
-vcf/ft/hrun_ft/%.hrun_ft.vcf : vcf/%.vcf
+vcf/%.hrun_ft.vcf : vcf/%.vcf
 	$(call LSCRIPT_CHECK_MEM,8G,12G,"$(call GATK_MEM,8G) -T VariantFiltration -R $(REF_FASTA) -V $< -o $@ \
 		--filterExpression 'HRun > $(HRUN_FILTER)' --filterName HRun")
 
-vcf/vaf_ft/%.vaf_ft.vcf : vcf/%.vcf
+vcf/%.vaf_ft.vcf : vcf/%.vcf
 	$(call LSCRIPT_CHECK_MEM,2G,5G,"$(call SNP_SIFT_MEM,2G) filter $(SNP_SIFT_OPTS) '(exists GEN[*].VAF) & (GEN[0].VAF > 0.05) & (GEN[1].VAF < 0.05)' < $< > $@")
 
 # target region filter
-vcf/ft/target_ft/%.target_ft.vcf : vcf/%.vcf
+vcf/%.target_ft.vcf : vcf/%.vcf
 	$(call LSCRIPT_CHECK_MEM,8G,12G,"$(call GATK_MEM2,8G) -T VariantFiltration -R $(REF_FASTA) -V $< -o $@ \
 		--mask $(TARGETS_FILE) --maskName targetInterval --filterNotInMask")
 
 # varscan depth filter (b/c varscan is dumb and only gives variant depth)
-vcf/ft/vdp_ft/%.vdp_ft.vcf : vcf/%.vcf
+vcf/%.vdp_ft.vcf : vcf/%.vcf
 	$(call LSCRIPT_CHECK_MEM,2G,5G,"cat $< | $(call SNP_SIFT_MEM,2G) filter $(SNP_SIFT_OPTS) '(exists GEN[*].AD) & (GEN[*].AD > $(DEPTH_FILTER))' > $@")
 
 ifdef SAMPLE_SET_PAIRS
 define somatic-filter-vcf-set
-vcf/som_ft/$1.%.som_ft.vcf : vcf/$1.%.vcf
+vcf/$1.%.som_ft.vcf : vcf/$1.%.vcf
 	$$(INIT) $$(SOMATIC_FILTER_VCF) -n $(normal.$1) -f 0.03 $$< > $$@ 2> $$(LOG)
 endef
 $(foreach set,$(SAMPLE_SET_PAIRS),$(eval $(call somatic-filter-vcf-set,$(set))))
@@ -61,7 +61,7 @@ ifdef SAMPLE_PAIRS
 # filter if normal depth > 20 and normal variant depth > 1/3 * tumor variant depth
 # or normal variant depth greater than 1
 define som-ad-ft-tumor-normal
-vcf/ft/som_ad_ft/$1_$2.%.som_ad_ft.vcf : vcf/$1_$2.%.vcf
+vcf/$1_$2.%.som_ad_ft.vcf : vcf/$1_$2.%.vcf
 	$$(call LSCRIPT_CHECK_MEM,8G,12G,"$$(call GATK_MEM,8G) -T VariantFiltration -R $$(REF_FASTA) -V $$< -o $$@ \
 		--filterExpression 'vc.getGenotype(\"$1\").getAD().1 < $(DEPTH_FILTER)' \
 		--filterName tumorVarAlleleDepth \
@@ -70,7 +70,7 @@ vcf/ft/som_ad_ft/$1_$2.%.som_ad_ft.vcf : vcf/$1_$2.%.vcf
 		--filterExpression 'vc.getGenotype(\"$1\").getDP() <= $$(DEPTH_FILTER) || vc.getGenotype(\"$2\").getDP() <= $$(DEPTH_FILTER)' \
 		--filterName depthFilter && sed -i 's/getGenotype(\"\([^\"]*\)\")/getGenotype(\1)/g' $$@")
 
-vcf/ft/ffpe_som_ad_ft/$1_$2.%.ffpe_som_ad_ft.vcf : vcf/$1_$2.%.vcf
+vcf/$1_$2.%.ffpe_som_ad_ft.vcf : vcf/$1_$2.%.vcf
 	$$(call LSCRIPT_CHECK_MEM,8G,12G,"$$(call GATK_MEM,8G) -T VariantFiltration -R $$(REF_FASTA) -V $$< -o $$@ \
 		--filterExpression 'vc.getGenotype(\"$1\").getAD().1 < $(DEPTH_FILTER)' \
 		--filterName tumorVarAlleleDepth \
@@ -80,7 +80,7 @@ vcf/ft/ffpe_som_ad_ft/$1_$2.%.ffpe_som_ad_ft.vcf : vcf/$1_$2.%.vcf
 		--filterName depthFilter && sed -i 's/getGenotype(\"\([^\"]*\)\")/getGenotype(\1)/g' $$@")
 
 # somatic filter for structural variants
-vcf/ft/sv_som_ft/$1_$2.%.sv_som_ft.vcf : vcf/$1_$2.%.vcf
+vcf/$1_$2.%.sv_som_ft.vcf : vcf/$1_$2.%.vcf
 	$$(call LSCRIPT_CHECK_MEM,8G,12G,"$$(call GATK_MEM,8G) -T VariantFiltration -R $$(REF_FASTA) -V $$< -o $$@ \
 		--filterExpression 'vc.getGenotype(\"$1\").getAnyAttribute(\"SU\") <= $$(DEPTH_FILTER)' \
 		--filterName svSupport \
@@ -92,11 +92,11 @@ endif
 
 NORMAL_VCF ?= $(HOME)/share/reference/spowellnormal.gatk_variants.vcf
 ifdef NORMAL_VCF
-vcf/nft/%.nft.vcf : vcf/%.vcf
+vcf/%.nft.vcf : vcf/%.vcf
 	$(call LSCRIPT_CHECK_MEM,8G,12G,"$(call GATK_MEM,8G) -T VariantFiltration -R $(REF_FASTA) -V $< -o $@ --maskName 'normal' --mask $(NORMAL_VCF)")
 
 # allele count filtering for hotspots: any alt allele count > 0
-vcf/ft/ac_ft/%.ac_ft.vcf : vcf/%.vcf
+vcf/%.ac_ft.vcf : vcf/%.vcf
 	$(call CHECK_VCF,$(call LSCRIPT_CHECK_MEM,9G,12G,"$(call SNP_SIFT_MEM,8G) filter \
 		$(SNP_SIFT_OPTS) \" ( AC[*] > 0 ) \" $< > $@"))
 endif

--- a/vcf_tools/vcfPostAnnotations.mk
+++ b/vcf_tools/vcfPostAnnotations.mk
@@ -3,11 +3,11 @@
 PROVEAN_SCRIPT = $(HOME)/share/usr/bin/provean.sh
 CLASSIFY_PATHOGENICITY = python modules/vcf_tools/classify_pathogenicity_vcf.py
 CLASSIFY_PATHOGENICITY_OPTS = --provean_script $(PROVEAN_SCRIPT) --qsub_script modules/scripts/qsub.pl --num_provean_threads 5 --mem_per_thread 1.5G 
-vcf/ann3/pathogen/%.pathogen.vcf : vcf/ann2/%.vcf
+vcf/%.pathogen.vcf : vcf/%.vcf
 	$(INIT) $(call CHECK_VCF,$(CLASSIFY_PATHOGENICITY) $(CLASSIFY_PATHOGENICITY_OPTS) $< > $@ 2> $(LOG))
 
 MUTATION_TASTER = $(PYTHON) modules/vcf_tools/mutation_taster_vcf.py
-vcf/ann2/mut_taste/%.mut_taste.vcf : vcf/ft2/%.vcf
+vcf/%.mut_taste.vcf : vcf/%.vcf
 	$(INIT) $(MUTATION_TASTER) $< > $@ 2> $(LOG)
 
 PROVEAN = $(RSCRIPT) modules/vcf_tools/proveanVcf.R
@@ -17,7 +17,7 @@ PROVEAN_OPTS = --genome $(REF) --aaTable $(AA_TABLE) --ensemblTxdb $(ENSEMBL_TXD
 			   --mysqlPort $(EMBL_MYSQLDB_PORT) --mysqlUser $(EMBL_MYSQLDB_USER) --mysqlPassword $(EMBL_MYSQLDB_PW) \
 			   --mysqlDb $(EMBL_MYSQLDB_DB) --numThreads 8 --memPerThread 1G --queue $(QUEUE) --qsubPriority $(QSUB_PRIORITY)
 
-vcf/ann2/provean/%.provean.vcf : vcf/ft2/%.vcf
+vcf/%.provean.vcf : vcf/%.vcf
 	$(call LSCRIPT_MEM,8G,10G,"$(PROVEAN) $(PROVEAN_OPTS) --outFile $@ $<")
 
 CHASM = $(RSCRIPT) modules/vcf_tools/chasmVcf.R 
@@ -35,29 +35,33 @@ FATHMM_PYTHONPATH = $(HOME)/share/usr/lib/python:$(HOME)/share/usr/lib/python2.7
 FATHMM_OPTS = --genome $(REF) --ensemblTxdb $(ENSEMBL_TXDB) --ref $(REF_FASTA) --fathmmDir $(FATHMM_DIR) --python $(FATHMM_PYTHON) \
 			  --mysqlHost $(EMBL_MYSQLDB_HOST) --mysqlPort $(EMBL_MYSQLDB_PORT) --mysqlUser $(EMBL_MYSQLDB_USER) --mysqlPassword $(EMBL_MYSQLDB_PW) --mysqlDb $(EMBL_MYSQLDB_DB)
 
-vcf/ann2/fathmm/%.fathmm.vcf : vcf/ft2/%.vcf
+vcf/%.fathmm.vcf : vcf/%.vcf
 	$(call CHECK_VCF,$(call LSCRIPT_CHECK_MEM,8G,10G,"PYTHONPATH=$(FATHMM_PYTHONPATH) $(FATHMM) $(FATHMM_OPTS) \
 		--outFile $@ $<"))
 
-ANNOTATE_FACETS_VCF = $(RSCRIPT) modules/copy_number/annotateFacets2Vcf.R
-define annotate-facets-pair
-vcf/ann2/facets/$1.%.facets.vcf : vcf/ft2/$1.%.vcf facets/cncf/$1.cncf.txt
-	$$(call LSCRIPT_MEM,4G,6G,"$$(ANNOTATE_FACETS_VCF) --facetsFile $$(<<) --outFile $$@ $$<")
-endef
-$(foreach pair,$(SAMPLE_PAIRS),$(eval $(call annotate-facets-pair,$(pair))))
 
 define hrun-tumor-normal
-vcf/ann2/hrun/$1_$2.%.hrun.vcf : vcf/ft2/$1_$2.%.vcf bam/$1.bam bam/$2.bam bam/$1.bai bam/$2.bai
+vcf/$1_$2.%.hrun.vcf : vcf/$1_$2.%.vcf bam/$1.bam bam/$2.bam bam/$1.bai bam/$2.bai
 	$$(call LSCRIPT_CHECK_PARALLEL_MEM,4,2G,3G,"$$(call GATK_MEM,8G) -T VariantAnnotator -nt 4 -R $$(REF_FASTA) -A HomopolymerRun --dbsnp $$(DBSNP) $$(foreach bam,$$(filter %.bam,$$^),-I $$(bam) ) -V $$< -L $$< -o $$@")
 endef
 $(foreach pair,$(SAMPLE_PAIRS),$(eval $(call hrun-tumor-normal,$(tumor.$(pair)),$(normal.$(pair)))))
 
 define hrun-sample
-vcf/ann2/hrun/$1.%.hrun.vcf : vcf/ft2/$1.%.vcf bam/$1.bam bam/$1.bai
+vcf/$1.%.hrun.vcf : vcf/$1.%.vcf bam/$1.bam bam/$1.bai
 	$$(call LSCRIPT_CHECK_PARALLEL_MEM,4,2G,3G,"$$(call GATK_MEM,8G) -T VariantAnnotator -nt 4 -R $$(REF_FASTA) -L $$< -A HomopolymerRun --dbsnp $$(DBSNP) $$(foreach bam,$$(filter %.bam,$$^),-I $$(bam) ) -V $$< -o $$@")
 endef
 $(foreach sample,$(SAMPLES),$(eval $(call hrun-sample,$(sample))))
 
 # run snp sift to annotated with dbnsfp
-vcf/ann2/nsfp/%.nsfp.vcf : vcf/ft2/%.vcf vcf/ft2/%.vcf.idx
+vcf/%.nsfp.vcf : vcf/%.vcf vcf/%.vcf.idx
 	$(call CHECK_VCF,$(call LSCRIPT_CHECK_MEM,9G,12G,"$(call SNP_SIFT_MEM,8G) dbnsfp $(SNP_SIFT_OPTS) -f $(subst $( ),$(,),$(NSFP_FIELDS)) -db $(DB_NSFP) $< | sed '/^##INFO=<ID=dbNSFP/ s/Character/String/; /^##INFO=<ID=dbNSFP_clinvar_rs/ s/Integer/String/;' > $@"))
+
+ifeq ($(ANN_FACETS),true)
+include modules/copy_number/facets.mk
+ANNOTATE_FACETS_VCF = $(RSCRIPT) modules/copy_number/annotateFacets2Vcf.R
+define annotate-facets-pair
+vcf/$1.%.facets.vcf : vcf/$1.%.vcf facets/cncf/$1.cncf.txt
+	$$(call LSCRIPT_MEM,4G,6G,"$$(ANNOTATE_FACETS_VCF) --facetsFile $$(<<) --outFile $$@ $$<")
+endef
+$(foreach pair,$(SAMPLE_PAIRS),$(eval $(call annotate-facets-pair,$(pair))))
+endif

--- a/vcf_tools/vcfPostFilters.mk
+++ b/vcf_tools/vcfPostFilters.mk
@@ -1,9 +1,9 @@
 # post-annotation filters
 VCF_POST_ANN_FILTER_EXPRESSION ?= ExAC_AF > 0.1
-vcf/ft2/cft/%.cft.vcf : vcf/ann/%.vcf
+vcf/%.cft.vcf : vcf/%.vcf
 	$(call CHECK_VCF,$(call LSCRIPT_CHECK_MEM,8G,12G,"$(call GATK_MEM,8G) -T VariantFiltration -R $(REF_FASTA) -V $< -o $@ \
 		--filterExpression '$(VCF_POST_ANN_FILTER_EXPRESSION)' --filterName customFilter"))
 
 COMMON_FILTER_VCF = $(PYTHON) modules/vcf_tools/common_filter_vcf.py
-vcf/ft2/common_ft/%.common_ft.vcf : vcf/ann/%.vcf
+vcf/%.common_ft.vcf : vcf/%.vcf
 	$(call CHECK_VCF,$(call LSCRIPT_MEM,4G,5G,"$(COMMON_FILTER_VCF) $< > $@"))


### PR DESCRIPTION
also cleaned up the annotation rules, removing the vcf subdirs that made the code rather messy and made rule reusability difficult
