### PR TITLE
Add PDX filter to remove mouse reads

### DIFF
--- a/aligners/align.inc
+++ b/aligners/align.inc
@@ -14,6 +14,7 @@ SEQ_PLATFORM ?= illumina
 BAM_SUFFIX := $(subst $( ),.,$(strip \
         $(if $(findstring false,$(BAM_NO_SORT)),sorted)\
         $(if $(findstring false,$(BAM_NO_FILTER)),filtered)\
+        $(if $(findstring true,$(PDX)),pdx_filtered)\
         $(if $(findstring true,$(BAM_FIX_RG)),rg)\
         $(if $(findstring false,$(BAM_NO_REALN)),realn)\
         $(if $(findstring rmdup,$(BAM_DUP_TYPE)),rmdup)\

--- a/aligners/bwamemAligner.mk
+++ b/aligners/bwamemAligner.mk
@@ -24,6 +24,7 @@ FASTQUTILS = $(HOME)/share/usr/ngsutils/bin/fastqutils
 
 BWA_ALN_OPTS ?= -M
 #BWA_ALN_OPTS ?= -q 20
+BWAMEM_REF_FASTA ?= $(REF_FASTA)
 
 ..DUMMY := $(shell mkdir -p version; $(BWA) &> version/bwamem.txt; echo "options: $(BWA_ALN_OPTS)" >> version/bwamem.txt )
 .SECONDARY:
@@ -41,17 +42,17 @@ bam/%.bam : bwamem/bam/%.bwamem.$(BAM_SUFFIX)
 #$(call align-split-fastq,name,split-name,fastqs)
 define align-split-fastq
 bwamem/bam/$2.bwamem.bam : $3
-	$$(call LSCRIPT_PARALLEL_MEM,8,1G,2G,"$$(BWA) mem -t 8 $$(BWA_ALN_OPTS) -R \"@RG\tID:$2\tLB:$1\tPL:$${SEQ_PLATFORM}\tSM:$1\" $$(REF_FASTA) $$^ | $$(SAMTOOLS) view -bhS - > $$@")
+	$$(call LSCRIPT_PARALLEL_MEM,8,1G,2G,"$$(BWA) mem -t 8 $$(BWA_ALN_OPTS) -R \"@RG\tID:$2\tLB:$1\tPL:$${SEQ_PLATFORM}\tSM:$1\" $$(BWAMEM_REF_FASTA) $$^ | $$(SAMTOOLS) view -bhS - > $$@")
 endef
 $(foreach ss,$(SPLIT_SAMPLES),$(if $(fq.$(ss)),$(eval $(call align-split-fastq,$(split.$(ss)),$(ss),$(fq.$(ss))))))
 
 bwamem/bam/%.bwamem.bam : fastq/%.1.fastq.gz fastq/%.2.fastq.gz
 	LBID=`echo "$*" | sed 's/_[A-Za-z0-9]\+//'`; \
-	$(call LSCRIPT_PARALLEL_MEM,8,1G,2G,"$(BWA) mem -t 8 $(BWA_ALN_OPTS) -R \"@RG\tID:$*\tLB:$${LBID}\tPL:${SEQ_PLATFORM}\tSM:$${LBID}\" $(REF_FASTA) $^ | $(SAMTOOLS) view -bhS - > $@")
+	$(call LSCRIPT_PARALLEL_MEM,8,1G,2G,"$(BWA) mem -t 8 $(BWA_ALN_OPTS) -R \"@RG\tID:$*\tLB:$${LBID}\tPL:${SEQ_PLATFORM}\tSM:$${LBID}\" $(BWAMEM_REF_FASTA) $^ | $(SAMTOOLS) view -bhS - > $@")
 
 bwamem/bam/%.bwamem.bam : fastq/%.fastq.gz
 	LBID=`echo "$*" | sed 's/_[A-Za-z0-9]\+//'`; \
-	$(call LSCRIPT_PARALLEL_MEM,8,1G,2G,"$(BWA) mem -t 8 $(BWA_ALN_OPTS) -R \"@RG\tID:$*\tLB:$${LBID}\tPL:${SEQ_PLATFORM}\tSM:$${LBID}\" $(REF_FASTA) $^ | $(SAMTOOLS) view -bhS - > $@")
+	$(call LSCRIPT_PARALLEL_MEM,8,1G,2G,"$(BWA) mem -t 8 $(BWA_ALN_OPTS) -R \"@RG\tID:$*\tLB:$${LBID}\tPL:${SEQ_PLATFORM}\tSM:$${LBID}\" $(BWAMEM_REF_FASTA) $^ | $(SAMTOOLS) view -bhS - > $@")
 
 fastq/%.fastq.gz : fastq/%.fastq
 	$(call LSCRIPT,"gzip -c $< > $(@) && $(RM) $<")

--- a/b37.inc
+++ b/b37.inc
@@ -40,6 +40,12 @@ MAPSPLICE_REF_BASENAME = $(REF_DIR)/GATK_bundle/2.3/mapsplice_ref/hg19
 
 GISTIC_REF ?= $(HOME)/share/usr/gistic_2_0_21/refgenefiles/hg19.mat
 
+# align to combined reference if PDX, filter mouse chromosomes afterwards
+PDX ?= false
+ifeq ($(PDX),true)
+BWAMEM_REF_FASTA ?= $(REF_DIR)/pdx/combined_Mus_musculus_GRCm38_human_g1k_v37.fasta
+endif
+
 REF_FASTA ?= $(REF_DIR)/GATK_bundle/2.3/human_g1k_v37.fasta
 REF_2BIT ?= $(REF_DIR)/GATK_bundle/2.3/human_g1k_v37.2bit
 DBSNP ?= $(REF_DIR)/dbsnp_138.b37.gmaf.vcf

--- a/bam_tools/processBam.mk
+++ b/bam_tools/processBam.mk
@@ -83,6 +83,11 @@ endif
 %.filtered.bam : %.bam
 	$(call LSCRIPT_MEM,6G,7G,"$(SAMTOOLS) view -bF $(BAM_FILTER_FLAGS) $< > $@ && $(RM) $<")
 
+# Remove reads mapping to chromomsomes prefixed with mouse, used for PDX
+# combined reference alignment. Filters mouse reads.
+%.pdx_filtered.bam : %.bam
+	$(call LSCRIPT_MEM,6G,7G,"($(SAMTOOLS) view -H $< | grep -v mouse; $(SAMTOOLS) view $< | grep -vP '\tmouse' ) | $(SAMTOOLS) view -bS - > $@ && $(RM) $<")
+
 %.fixmate.bam : %.bam
 	$(call LSCRIPT_MEM,9G,14G,"$(call FIX_MATE_MEM,8G) I=$< O=$@ && $(RM) $<")
 


### PR DESCRIPTION
Add alignment against combined human+mouse reference for b37 when `pdx:true` in
config file. Afterwards filter out all mouse reads so resulting bam file looks
like it was aligned against b37 instead of the combined ref.
