### PR TITLE
Muttype heatmap, facets germ thresh, pyvcf version

### DIFF
--- a/clonality/absoluteSeq.mk
+++ b/clonality/absoluteSeq.mk
@@ -1,5 +1,6 @@
 # run absolute using strelka,mutect,scalpel,titan,oncoscan OR varscan_cnv
 include modules/Makefile.inc
+include modules/vcf_tools/vcftools.mk
 
 LOGDIR = log/absoluteSeq.$(NOW)
 MEM := 4G
@@ -31,10 +32,12 @@ USE_ONCOSCAN_COPYNUM ?= false
 USE_FACETS_COPYNUM ?= true
 
 define LIB_INIT
-pacman::p_load(ABSOLUTE, dplyr, stringr, readr)
+for (lib in c("dplyr","stringr","readr","ABSOLUTE")) {
+    suppressPackageStartupMessages(library(lib, character.only=TRUE))
+}
 endef
 
-absolute/tables/%.somatic.txt : tables/%.mutect_snps.tab.txt tables/%.mutect_indels.tab.txt
+absolute/tables/%.somatic.txt : tables/%.mutect.tab.txt tables/%.strelka_varscan_indels.tab.txt
 
 	$(R_INIT)
 	$(LIB_INIT)

--- a/copy_number/facets.mk
+++ b/copy_number/facets.mk
@@ -13,8 +13,12 @@ FACETS_PRE_CVAL ?= 50
 FACETS_CVAL1 ?= 150
 FACETS_CVAL2 ?= 50
 FACETS_MIN_NHET ?= 25
+FACETS_HET_THRESHOLD ?= 0.25
 FACETS_GATK_VARIANTS ?= false
-FACETS_OPTS = --cval2 $(FACETS_CVAL2) --cval1 $(FACETS_CVAL1) --genome $(REF) --min_nhet $(FACETS_MIN_NHET) --pre_cval $(FACETS_PRE_CVAL)
+FACETS_OPTS = --cval2 $(FACETS_CVAL2) --cval1 $(FACETS_CVAL1) --genome $(REF) \
+			  --het_threshold $(FACETS_HET_THRESHOLD) \
+			  --min_nhet $(FACETS_MIN_NHET) \
+			  --pre_cval $(FACETS_PRE_CVAL)
 
 SNP_PILEUP = $(HOME)/share/usr/bin/snp-pileup
 SNP_PILEUP_OPTS = --min-map-quality=15 --min-base-quality=20 --gzip
@@ -69,12 +73,12 @@ facets/vcf/targets_dbsnp.vcf.gz : $(TARGETS_FILE)
 
 define snp-pileup-tumor-normal
 facets/snp_pileup/$1_$2.snp_pileup.gz : bam/$1.bam bam/$2.bam $$(FACETS_SNP_VCF)
-	$$(call LSCRIPT_CHECK_MEM,8G,20G,"$$(SNP_PILEUP) $$(SNP_PILEUP_OPTS) <(zcat $$(<<<)) $$@ $$< $$(<<)")
+	$$(call LSCRIPT_CHECK_MEM,8G,20G,"rm -f $$@ && $$(SNP_PILEUP) $$(SNP_PILEUP_OPTS) <(zcat $$(<<<)) $$@ $$< $$(<<)")
 endef
 $(foreach pair,$(SAMPLE_PAIRS),$(eval $(call snp-pileup-tumor-normal,$(tumor.$(pair)),$(normal.$(pair)))))
 
 facets/cncf/%.cncf.txt : facets/snp_pileup/%.snp_pileup.gz
-	$(call LSCRIPT_CHECK_MEM,8G,30G,"$(RUN_FACETS) $(FACETS_OPTS) --outPrefix $(@D)/$* $<")
+	$(call LSCRIPT_CHECK_MEM,8G,30G,"$(RUN_FACETS) $(FACETS_OPTS) --out_prefix $(@D)/$* $<")
 
 facets/geneCN.txt : $(foreach pair,$(SAMPLE_PAIRS),facets/cncf/$(pair).cncf.txt)
 	$(call LSCRIPT_CHECK_MEM,8G,30G,"$(FACETS_GENE_CN) $(FACETS_GENE_CN_OPTS) --outFile $@ $^")

--- a/copy_number/runFacets.R
+++ b/copy_number/runFacets.R
@@ -26,9 +26,10 @@ optList <- list(
                 make_option("--cval2", default = 50, type = 'integer', help = "starting critical value for segmentation (increases by 10 until success)"),
                 make_option("--max_cval", default = 5000, type = 'integer', help = "maximum critical value for segmentation (increases by 10 until success)"),
                 make_option("--min_nhet", default = 25, type = 'integer', help = "minimum number of heterozygote snps in a segment used for bivariate t-statistic during clustering of segment"),
+                make_option("--het_threshold", default = 0.25, type = 'double', help = "AF threshold for heterozygous SNPs"),
                 make_option("--gene_loc_file", default = '~/share/reference/IMPACT410_genes_for_copynumber.txt', type = 'character', help = "file containing gene locations"),
                 make_option("--genome", default = 'b37', type = 'character', help = "genome of counts file"),
-                make_option("--outPrefix", default = NULL, help = "output prefix"))
+                make_option("--out_prefix", default = NULL, help = "output prefix"))
 
 parser <- OptionParser(usage = "%prog [options] [tumor-normal base counts file]", option_list = optList);
 
@@ -39,7 +40,7 @@ if (length(arguments$args) < 1) {
     cat("Need base counts file\n")
     print_help(parser);
     stop();
-} else if (is.null(opt$outPrefix)) {
+} else if (is.null(opt$out_prefix)) {
     cat("Need output prefix\n")
     print_help(parser);
     stop();
@@ -84,7 +85,7 @@ cat("\n")
 
 
 snpmat <- readSnpMatrix(snpPileupFile)
-preOut <- snpmat %>% preProcSample(snp.nbhd = opt$snp_nbhd, cval = opt$pre_cval, gbuild = facetsGenome)
+preOut <- snpmat %>% preProcSample(snp.nbhd = opt$snp_nbhd, het.thresh = opt$het_threshold, cval = opt$pre_cval, gbuild = facetsGenome)
 out1 <- preOut %>% procSample(cval = opt$cval1, min.nhet = opt$min_nhet)
 
 cval <- opt$cval2
@@ -109,11 +110,11 @@ if (!success) {
 }
 
 
-#CairoPNG(file = str_c(opt$outPrefix,".biseg.png"), height = 1000, width = 800)
+#CairoPNG(file = str_c(opt$out_prefix,".biseg.png"), height = 1000, width = 800)
 #plotSample(out2, chromlevels = chromLevels)
 #dev.off()
 
-#pdf(file = str_c(opt$outPrefix, ".biseg.pdf"), height = 12, width = 9)
+#pdf(file = str_c(opt$out_prefix, ".biseg.pdf"), height = 12, width = 9)
 #plotSample(out2, chromlevels = chromLevels)
 #dev.off()
 
@@ -134,9 +135,9 @@ formatSegmentOutput=function(out,sampID) {
 }
 id <- paste(tumorName, normalName, sep = '_')
 out2$IGV = formatSegmentOutput(out2, id)
-save(out2, fit, file = str_c(opt$outPrefix, ".Rdata"), compress=T)
+save(out2, fit, file = str_c(opt$out_prefix, ".Rdata"), compress=T)
 
-ff = str_c(opt$outPrefix, ".out")
+ff = str_c(opt$out_prefix, ".out")
 cat("# Version =", version, "\n", file = ff, append = T)
 cat("# Input =", basename(snpPileupFile), "\n", file = ff, append = T)
 cat("# tumor =", tumorName, "\n", file = ff, append = T)
@@ -152,24 +153,24 @@ cat("# dipLogR =", fit$dipLogR, "\n", file = ff, append = T)
 cat("# dipt =", fit$dipt, "\n", file = ff, append = T)
 cat("# loglik =", fit$loglik, "\n", file = ff, append = T)
 
-CairoPNG(file = str_c(opt$outPrefix, ".lrr.png"), height = 400, width = 850)
+CairoPNG(file = str_c(opt$out_prefix, ".lrr.png"), height = 400, width = 850)
 plotSampleLRR(out2, fit)
 dev.off()
 
-pdf(file = str_c(opt$outPrefix, ".lrr.pdf"), height = 3, width = 9)
+pdf(file = str_c(opt$out_prefix, ".lrr.pdf"), height = 3, width = 9)
 plotSampleLRR(out2, fit)
 dev.off()
 
-CairoPNG(file = str_c(opt$outPrefix, ".cncf.png"), height = 1100, width = 850)
+CairoPNG(file = str_c(opt$out_prefix, ".cncf.png"), height = 1100, width = 850)
 plotSample(out2, fit)
 dev.off()
 
-pdf(file = str_c(opt$outPrefix, ".cncf.pdf"), height = 9, width = 9)
+pdf(file = str_c(opt$out_prefix, ".cncf.pdf"), height = 9, width = 9)
 plotSample(out2, fit)
 dev.off()
 
 tab <- cbind(select(out2$IGV, ID:num.mark), select(fit$cncf, -start, -end, -chrom, -num.mark))
-write.table(tab, str_c(opt$outPrefix, ".cncf.txt"), row.names = F, quote = F, sep = '\t')
+write.table(tab, str_c(opt$out_prefix, ".cncf.txt"), row.names = F, quote = F, sep = '\t')
 
 warnings()
 

--- a/external/SNVBox/snv_box.conf
+++ b/external/SNVBox/snv_box.conf
@@ -1,8 +1,8 @@
 ; SNV-Box configuration file
 ; Contains the Database specifications
 chasmDB=CHASM
-db.user=chasm
-db.password=chasm
-db.host=gg03
-db.port=9991
+db.user=chasm_user
+db.password=password
+db.host=10.0.200.71
+db.port=38493
 ;db.unix_socket=/tmp/mysql.sock

--- a/scripts/Rshell
+++ b/scripts/Rshell
@@ -59,6 +59,7 @@ if [[ -n "$R" ]]; then
     echo "${R}" >> ${TMP}
     echo "${R}" > $LOGDIR/$NAME.R
     chmod +rx ${TMP}
+    source ${HOME}/.bashrc
     if [[ -n "$SGE" ]]; then
         mkdir -p $LOGDIR
         echo "umask 002; ${RCMD} ${TMP}" | $QSUB -- -cwd -V -now n -q $QUEUE -N X$NAME $PE -l virtual_free=$MEM,h_vmem=$MEM -o $LOGDIR/$NAME.log -j y -b n

--- a/scripts/classify_pathogenicity_vcf.py
+++ b/scripts/classify_pathogenicity_vcf.py
@@ -393,17 +393,13 @@ if __name__ == "__main__":
 
     # add necessary info headers
     vcf_reader.infos['pathogenicity'] = vcf.parser._Info(id='pathogenicity', num=-1, type='String',
-                                                         desc="Classification of pathogenicity",
-                                                         source=None, version=None)
+                                                         desc="Classification of pathogenicity")
     vcf_reader.infos['provean_protein_id'] = vcf.parser._Info(id='provean_protein_id', num=-1, type='String',
-                                                              desc="provean protein id (run if necessary)",
-                                                              source=None, version=None)
+                                                              desc="provean protein id (run if necessary)")
     vcf_reader.infos['provean_pred'] = vcf.parser._Info(id='provean_pred', num=-1, type='String',
-                                                        desc="provean prediction (run if necessary)",
-                                                        source=None, version=None)
+                                                        desc="provean prediction (run if necessary)")
     vcf_reader.infos['provean_score'] = vcf.parser._Info(id='provean_score', num=-1, type='Float',
-                                                         desc="provean score (run if necessary)",
-                                                         source=None, version=None)
+                                                         desc="provean score (run if necessary)")
 
     vcf_writer = vcf.Writer(sys.stdout, vcf_reader)
 

--- a/summary/mutationSummary.mk
+++ b/summary/mutationSummary.mk
@@ -6,8 +6,13 @@ LOGDIR = log/summary.$(NOW)
 .DELETE_ON_ERROR:
 
 
+<<<<<<< Updated upstream
 SNV_TYPE ?= mutect_snps
 INDEL_TYPE ?= somatic_indels
+=======
+SNV_TYPE ?= mutect# mutect_snps #mutect
+INDEL_TYPE ?= strelka_varscan_indels# mutect_indels #strelka_varscan_indels
+>>>>>>> Stashed changes
 
 HOTSPOT_TABLE = alltables/allTN.hotspot.tab.txt
 ALLTABLES_HIGH_MODERATE_SNVS = alltables/allTN.$(SNV_TYPE).tab.high_moderate.txt
@@ -21,8 +26,8 @@ ALLTABLES_NONSYNONYMOUS_INDELS = alltables/allTN.$(INDEL_TYPE).tab.nonsynonymous
 
 # Add optional absolute results to excel
 # the $(wildcard x) syntax is used to check for existence of file
-ABSOLUTE_SOMATIC_TXTS ?= $(wildcard $(foreach set,$(SAMPLE_SETS),absolute/tables/$(set).somatic.txt))
-ABSOLUTE_SEGMENTS ?= $(wildcard $(foreach set,$(SAMPLE_SETS),absolute/reviewed/SEG_MAF/$(set)_ABS_MAF.txt))
+ABSOLUTE_SOMATIC_TXTS ?= $(wildcard $(foreach set,$(SAMPLE_PAIRS),absolute/tables/$(set).somatic.txt))
+ABSOLUTE_SEGMENTS ?= $(wildcard $(foreach set,$(SAMPLE_PAIRS),absolute/reviewed/SEG_MAF/$(set)_ABS_MAF.txt))
 ifneq ($(and $(ABSOLUTE_SOMATIC_TXTS),$(ABSOLUTE_SEGMENTS)),)
 EXCEL_ABSOLUTE_PARAMS = --absolute_segments $(subst $(space),$(,),$(strip $(ABSOLUTE_SEGMENTS))) --absolute_somatic_txts $(subst $(space),$(,),$(strip $(ABSOLUTE_SOMATIC_TXTS)))
 endif

--- a/vcf_tools/annotateSomaticVcf.mk
+++ b/vcf_tools/annotateSomaticVcf.mk
@@ -12,10 +12,14 @@ ifeq ($(CLUSTER_ENGINE),"PBS")
 ..DUMMY := $(shell python modules/scripts/launcher_sql_db.py modules/db/ensembl-hs-core-85-37_db.yaml)
 endif
 
+<<<<<<< Updated upstream
 SNV_TYPE ?= mutect_snps
 INDEL_TYPE ?= somatic_indels
 #strelka_indels varscan_indels strelka_varscan_indels
 VARIANT_TYPES ?= $(SNV_TYPE) $(INDEL_TYPE)
+=======
+VARIANT_TYPES ?= mutect strelka_varscan_indels # mutect_snps somatic_indels #strelka_indels varscan_indels strelka_varscan_indels
+>>>>>>> Stashed changes
 
 
 DEPTH_FILTER ?= 5
@@ -71,9 +75,10 @@ SOMATIC_ANN3 += pathogen
 endif
 
 PHONY += all somatic_vcfs merged_vcfs
-all : somatic_vcfs merged_vcfs
+all : somatic_vcfs merged_vcfs somatic_tables
 merged_vcfs : $(foreach pair,$(SAMPLE_PAIRS),vcf_ann/$(pair).merged.vcf.gz)
 somatic_vcfs : $(foreach type,$(VARIANT_TYPES),$(type)_vcfs)
+somatic_tables : $(foreach pair,$(SAMPLE_PAIRS),$(foreach type,$(VARIANT_TYPES),tables/$(pair).$(type).tab.txt))
 
 MERGE_VCF = $(PYTHON) modules/vcf_tools/merge_vcf.py
 MERGE_SCRIPT = $(call LSCRIPT_MEM,6G,7G,"$(MERGE_VCF) --out_file $@ $^")

--- a/vcf_tools/mutation_taster_vcf.py
+++ b/vcf_tools/mutation_taster_vcf.py
@@ -18,10 +18,10 @@ if __name__ == "__main__":
 
     vcf_reader.infos['MutationTaster_pred'] = vcf.parser._Info(id='MutationTaster_pred', num=-1, type='String',
                                                             desc="Mutation taster prediction using webquery if indel or"
-                                                            " dbNSFP if it exists", source=None, version=None)
+                                                            " dbNSFP if it exists")
     vcf_reader.infos['MutationTaster_score'] = vcf.parser._Info(id='MutationTaster_score', num=-1, type='Float',
                                                                 desc="Mutation taster score using webquery if indel or"
-                                                                " dbNSFP if it exists", source=None, version=None)
+                                                                " dbNSFP if it exists")
 
     vcf_writer = vcf.Writer(sys.stdout, vcf_reader)
 


### PR DESCRIPTION
These changes were driven by Tari King's cfDNA project:
- Add germline threshold for SNPs. Without it the cfDNA/tumor samples wouldn't
  match.
- Add same threshold for Facets
- Different pyvcf version, does not have `source=` option in function call
- Add mutation type heatmap that has the same gene/sample ordering as the ccf
  heatmap. Based on @hxrts Pascal heatmap
